### PR TITLE
feat: Automatic late fees for overdue payment

### DIFF
--- a/contracts/creditline-contract/src/events.rs
+++ b/contracts/creditline-contract/src/events.rs
@@ -8,6 +8,7 @@ const LOAN_REQUESTED: Symbol = symbol_short!("LOANRQST");
 const LOAN_DEFAULTED: Symbol = symbol_short!("LOANDFLT");
 const LOAN_REPAID: Symbol = symbol_short!("LOANRPD");
 const LOAN_CANCELLED: Symbol = symbol_short!("LOANCNCL");
+const LOAN_LATE_FEE: Symbol = symbol_short!("LOANLTFE");
 
 /// Emit a loan created event
 pub fn emit_loan_created(
@@ -92,5 +93,18 @@ pub fn emit_loan_cancelled(env: &Env, borrower: &Address, loan_id: u64, refunded
     env.events().publish(
         (LOAN_CANCELLED, borrower, loan_id),
         (refunded_guarantee, env.ledger().timestamp()),
+    );
+}
+
+pub fn emit_late_fee_accrued(
+    env: &Env,
+    borrower: &Address,
+    loan_id: u64,
+    fee_amount: i128,
+    new_remaining_balance: i128,
+) {
+    env.events().publish(
+        (LOAN_LATE_FEE, borrower, loan_id),
+        (fee_amount, new_remaining_balance, env.ledger().timestamp()),
     );
 }

--- a/contracts/creditline-contract/src/lib.rs
+++ b/contracts/creditline-contract/src/lib.rs
@@ -349,6 +349,8 @@ impl CreditLineContract {
             status,
             created_at: env.ledger().timestamp(),
             funded_at: 0,
+            late_fees_outstanding: 0,
+            late_fee_accrual_timestamp: 0,
         }
     }
 
@@ -492,12 +494,21 @@ impl CreditLineContract {
             panic_with_error!(&env, CreditLineError::LoanNotActive);
         }
 
+        // Accrue any outstanding late fees before validating the payment amount so
+        // the borrower repays the true current balance (principal + interest + fees + late fees).
+        let accrued_fee = Self::accrue_late_fees_internal(&env, &mut loan);
+        if accrued_fee > 0 {
+            storage::increase_user_active_debt(&env, &borrower, accrued_fee);
+            events::emit_late_fee_accrued(&env, &borrower, loan_id, accrued_fee, loan.remaining_balance);
+        }
+
         if amount <= 0 || amount > loan.remaining_balance {
             panic_with_error!(&env, CreditLineError::InvalidRepaymentAmount);
         }
 
         Self::enter_non_reentrant(&env);
 
+        // Payment priority: principal → interest → service fee → late fees
         let principal_paid = amount.min(loan.principal_outstanding);
         let after_principal = amount
             .checked_sub(principal_paid)
@@ -507,6 +518,10 @@ impl CreditLineContract {
             .checked_sub(interest_paid)
             .unwrap_or_else(|| panic_with_error!(&env, CreditLineError::Underflow));
         let fee_paid = after_interest.min(loan.service_fee_outstanding);
+        let after_fee = after_interest
+            .checked_sub(fee_paid)
+            .unwrap_or_else(|| panic_with_error!(&env, CreditLineError::Underflow));
+        let late_fee_paid = after_fee.min(loan.late_fees_outstanding);
 
         loan.principal_outstanding = loan
             .principal_outstanding
@@ -519,6 +534,10 @@ impl CreditLineContract {
         loan.service_fee_outstanding = loan
             .service_fee_outstanding
             .checked_sub(fee_paid)
+            .unwrap_or_else(|| panic_with_error!(&env, CreditLineError::Underflow));
+        loan.late_fees_outstanding = loan
+            .late_fees_outstanding
+            .checked_sub(late_fee_paid)
             .unwrap_or_else(|| panic_with_error!(&env, CreditLineError::Underflow));
 
         let new_balance = loan
@@ -550,6 +569,7 @@ impl CreditLineContract {
             &principal_paid,
             &interest_paid
                 .checked_add(fee_paid)
+                .and_then(|v| v.checked_add(late_fee_paid))
                 .unwrap_or_else(|| panic_with_error!(&env, CreditLineError::Overflow)),
         );
 
@@ -584,6 +604,110 @@ impl CreditLineContract {
 
         Self::exit_non_reentrant(&env);
         new_balance
+    }
+
+    /// Accrue late fees for a loan and update the caller-supplied `loan` in place.
+    ///
+    /// Fees are calculated as `remaining_balance × LATE_FEE_BPS_PER_DAY × days_overdue`
+    /// starting from the earliest overdue installment due date (or the previous accrual
+    /// timestamp, whichever is later). Only complete days are counted; any partial day
+    /// carries over to the next accrual.
+    ///
+    /// Returns the newly accrued fee amount (0 if nothing was due).
+    fn accrue_late_fees_internal(env: &Env, loan: &mut Loan) -> i128 {
+        let now = env.ledger().timestamp();
+
+        // Find the earliest overdue installment due date.
+        let mut overdue_since: Option<u64> = None;
+        for installment in loan.repayment_schedule.iter() {
+            if installment.due_date < now {
+                overdue_since = Some(match overdue_since {
+                    None => installment.due_date,
+                    Some(d) => {
+                        if installment.due_date < d {
+                            installment.due_date
+                        } else {
+                            d
+                        }
+                    }
+                });
+            }
+        }
+
+        let overdue_since = match overdue_since {
+            Some(d) => d,
+            None => return 0, // no overdue installments
+        };
+
+        // Accrue from the later of (first overdue date, last accrual timestamp).
+        let accrual_start = if loan.late_fee_accrual_timestamp == 0 {
+            overdue_since
+        } else if loan.late_fee_accrual_timestamp > overdue_since {
+            loan.late_fee_accrual_timestamp
+        } else {
+            overdue_since
+        };
+
+        if now <= accrual_start {
+            return 0;
+        }
+
+        let seconds_elapsed = now - accrual_start;
+        let days_elapsed = (seconds_elapsed / types::SECONDS_PER_DAY) as i128;
+
+        if days_elapsed == 0 {
+            return 0; // less than one full day has passed since last accrual
+        }
+
+        let fee = loan
+            .remaining_balance
+            .checked_mul(types::LATE_FEE_BPS_PER_DAY)
+            .and_then(|v| v.checked_mul(days_elapsed))
+            .and_then(|v| v.checked_div(types::BPS_DENOMINATOR))
+            .unwrap_or(0);
+
+        if fee == 0 {
+            return 0;
+        }
+
+        // Advance the accrual cursor by only complete days to avoid losing fractions.
+        loan.late_fee_accrual_timestamp =
+            accrual_start + (days_elapsed as u64) * types::SECONDS_PER_DAY;
+
+        loan.late_fees_outstanding = loan
+            .late_fees_outstanding
+            .checked_add(fee)
+            .unwrap_or(loan.late_fees_outstanding);
+        loan.remaining_balance = loan
+            .remaining_balance
+            .checked_add(fee)
+            .unwrap_or(loan.remaining_balance);
+
+        fee
+    }
+
+    /// Apply late fees to an active loan without requiring a repayment.
+    ///
+    /// Anyone may call this to trigger fee accrual on an overdue loan.  Emits a
+    /// `LOANLTFE` event when fees are accrued; is a no-op when no full day has
+    /// elapsed since the last accrual or when no installment is overdue.
+    pub fn apply_late_fees(env: Env, loan_id: u64) {
+        let mut loan = storage::read_loan(&env, loan_id)
+            .unwrap_or_else(|| panic_with_error!(&env, CreditLineError::LoanNotFound));
+
+        if loan.status != LoanStatus::Active {
+            panic_with_error!(&env, CreditLineError::LoanNotActive);
+        }
+
+        let accrued_fee = Self::accrue_late_fees_internal(&env, &mut loan);
+
+        if accrued_fee == 0 {
+            return;
+        }
+
+        storage::increase_user_active_debt(&env, &loan.borrower, accrued_fee);
+        storage::write_loan(&env, &loan);
+        events::emit_late_fee_accrued(&env, &loan.borrower, loan_id, accrued_fee, loan.remaining_balance);
     }
 
     fn get_protocol_parameters(env: &Env) -> ProtocolParameters {

--- a/contracts/creditline-contract/src/tests.rs
+++ b/contracts/creditline-contract/src/tests.rs
@@ -2166,3 +2166,236 @@ fn test_end_to_end_default_path_guarantee_and_penalty() {
     assert_eq!(t.balance(&t.pool.address), pool_balance_after_loan + 200);
     assert_eq!(pool_stats.locked_liquidity, 600);
 }
+
+// ─── late fee tests ───────────────────────────────────────────────────────────
+
+// LATE_FEE_BPS_PER_DAY = 50, BPS_DENOMINATOR = 10_000, SECONDS_PER_DAY = 86_400
+// For DEFAULT_TOTAL_DUE = 1_050: fee per day = 1050 * 50 / 10_000 = 5
+
+const SECONDS_PER_DAY: u64 = 86_400;
+
+#[test]
+fn test_no_late_fee_before_due_date() {
+    // A loan repaid before its due date must have zero late fees
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    t.env.ledger().set_timestamp(1_000);
+    let due_date = 50_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    let loan = t.client.get_loan(&loan_id);
+    assert_eq!(loan.late_fees_outstanding, 0);
+    assert_eq!(loan.late_fee_accrual_timestamp, 0);
+}
+
+#[test]
+fn test_apply_late_fees_adds_fee_after_one_day_overdue() {
+    // apply_late_fees after exactly 1 full day overdue must add 5 to remaining_balance
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 1_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    // Advance 1 full day past due_date
+    t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+
+    let loan = t.client.get_loan(&loan_id);
+    // fee = 1050 * 50 / 10_000 = 5
+    assert_eq!(loan.late_fees_outstanding, 5);
+    assert_eq!(loan.remaining_balance, DEFAULT_TOTAL_DUE + 5);
+}
+
+#[test]
+fn test_apply_late_fees_accumulates_over_multiple_days() {
+    // 3 days overdue → fee = 1050 * 50 * 3 / 10_000 = 15
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 1_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    t.env.ledger().set_timestamp(due_date + 3 * SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+
+    let loan = t.client.get_loan(&loan_id);
+    assert_eq!(loan.late_fees_outstanding, 15);
+    assert_eq!(loan.remaining_balance, DEFAULT_TOTAL_DUE + 15);
+}
+
+#[test]
+fn test_apply_late_fees_is_noop_within_same_day() {
+    // Calling apply_late_fees twice within the same day must not double-count
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 1_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+
+    // Second call within the same second — no additional day has elapsed
+    t.client.apply_late_fees(&loan_id);
+
+    let loan = t.client.get_loan(&loan_id);
+    assert_eq!(loan.late_fees_outstanding, 5); // still just 1 day
+}
+
+#[test]
+fn test_apply_late_fees_incremental_across_two_calls() {
+    // Day 1 call then day 2 call should each contribute one day's fee
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 0_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    // due_date == 0, so it's already overdue at creation time; first day starts at ledger 0
+    // Advance ledger to 1 so due_date < now and create the loan
+    t.env.ledger().set_timestamp(1);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    // First accrual: 1 day after due_date (due_date = 0, now = SECONDS_PER_DAY)
+    t.env.ledger().set_timestamp(SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+    let after_day1 = t.client.get_loan(&loan_id).late_fees_outstanding;
+
+    // Second accrual: another full day later
+    t.env.ledger().set_timestamp(2 * SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+    let after_day2 = t.client.get_loan(&loan_id).late_fees_outstanding;
+
+    // Day 1 fee: 1050 * 50 / 10_000 = 5
+    // Day 2 fee is on the new balance (1055): 1055 * 50 / 10_000 = 5 (integer division)
+    assert_eq!(after_day1, 5);
+    assert!(after_day2 > after_day1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")] // LoanNotActive
+fn test_apply_late_fees_on_paid_loan_fails() {
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+    let loan_id = t.create_default_loan(&user, &merchant);
+
+    t.mint(&user, DEFAULT_TOTAL_DUE);
+    t.client.repay_loan(&user, &loan_id, &DEFAULT_TOTAL_DUE);
+
+    // Past due date — but loan is already Paid; should reject
+    t.env.ledger().set_timestamp(100_000);
+    t.client.apply_late_fees(&loan_id);
+}
+
+#[test]
+fn test_repay_loan_auto_accrues_late_fees() {
+    // repay_loan must accrue outstanding late fees before processing payment
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 1_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    // Advance 1 day past due_date and attempt partial payment
+    t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
+    // fee = 5; provide enough to cover only the original balance
+    t.mint(&user, DEFAULT_TOTAL_DUE);
+    // Pay only the original balance — should leave late fees outstanding
+    t.client.repay_loan(&user, &loan_id, &DEFAULT_TOTAL_DUE);
+
+    let loan = t.client.get_loan(&loan_id);
+    // Loan is still Active: original balance paid but late fees remain
+    assert_eq!(loan.status, LoanStatus::Active);
+    assert_eq!(loan.late_fees_outstanding, 5);
+    assert_eq!(loan.remaining_balance, 5);
+}
+
+#[test]
+fn test_full_repayment_including_late_fees_sets_paid() {
+    // Borrower paying remaining_balance after late-fee accrual closes the loan
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 1_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+
+    let loan = t.client.get_loan(&loan_id);
+    let total_due = loan.remaining_balance; // DEFAULT_TOTAL_DUE + 5
+
+    t.mint(&user, total_due);
+    t.client.repay_loan(&user, &loan_id, &total_due);
+
+    let loan = t.client.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Paid);
+    assert_eq!(loan.remaining_balance, 0);
+    assert_eq!(loan.late_fees_outstanding, 0);
+}
+
+#[test]
+fn test_active_debt_includes_late_fees() {
+    // apply_late_fees must increase the borrower's active debt by the fee amount
+    let t = TestCtx::setup();
+    let user = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+
+    let due_date = 1_000_u64;
+    let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
+    t.env.ledger().set_timestamp(0);
+    t.mint(&user, DEFAULT_GUARANTEE);
+    let loan_id = t
+        .client
+        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+
+    let debt_before = t.client.get_user_active_debt(&user);
+
+    t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
+    t.client.apply_late_fees(&loan_id);
+
+    let debt_after = t.client.get_user_active_debt(&user);
+    assert_eq!(debt_after, debt_before + 5);
+}

--- a/contracts/creditline-contract/src/tests.rs
+++ b/contracts/creditline-contract/src/tests.rs
@@ -2181,6 +2181,7 @@ fn test_no_late_fee_before_due_date() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     t.env.ledger().set_timestamp(1_000);
     let due_date = 50_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
@@ -2201,6 +2202,7 @@ fn test_apply_late_fees_adds_fee_after_one_day_overdue() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 1_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
@@ -2226,6 +2228,7 @@ fn test_apply_late_fees_accumulates_over_multiple_days() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 1_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
@@ -2249,6 +2252,7 @@ fn test_apply_late_fees_is_noop_within_same_day() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 1_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
@@ -2274,6 +2278,7 @@ fn test_apply_late_fees_incremental_across_two_calls() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 0_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
@@ -2324,6 +2329,7 @@ fn test_repay_loan_auto_accrues_late_fees() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 1_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
@@ -2353,6 +2359,7 @@ fn test_full_repayment_including_late_fees_sets_paid() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 1_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
@@ -2383,6 +2390,7 @@ fn test_active_debt_includes_late_fees() {
     let user = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
 
+    t.register_merchant(&merchant, "Test Merchant");
     let due_date = 1_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);

--- a/contracts/creditline-contract/src/types.rs
+++ b/contracts/creditline-contract/src/types.rs
@@ -38,8 +38,10 @@ pub struct Loan {
     pub remaining_balance: i128,
     pub repayment_schedule: soroban_sdk::Vec<RepaymentInstallment>,
     pub status: LoanStatus,
-    pub created_at: u64, // Unix timestamp
-    pub funded_at: u64,  // 0 means not funded yet
+    pub created_at: u64,                  // Unix timestamp
+    pub funded_at: u64,                   // 0 means not funded yet
+    pub late_fees_outstanding: i128,      // accumulated unpaid late fees
+    pub late_fee_accrual_timestamp: u64,  // last accrual timestamp (0 = never accrued)
 }
 
 pub fn default_protocol_parameters() -> ProtocolParameters {
@@ -51,3 +53,5 @@ pub const MIN_GUARANTEE_PERCENT: i128 = 20; // 20% minimum guarantee
 pub const MIN_REPUTATION_THRESHOLD: u32 = 50; // Minimum reputation score required
 pub const SERVICE_FEE_BPS: i128 = 100; // 1% flat service fee
 pub const BPS_DENOMINATOR: i128 = 10_000;
+pub const LATE_FEE_BPS_PER_DAY: i128 = 50; // 0.5% of remaining balance per overdue day
+pub const SECONDS_PER_DAY: u64 = 86_400;


### PR DESCRIPTION
# Pull Request

## Description
Implements automatic late fee accrual for overdue loan installments. When a borrower misses a due date, a daily penalty of 0.5% of the remaining balance accumulates until the loan is repaid or defaults. Fees are lazily accrued — they are applied automatically when `repay_loan` is called, and can also be triggered externally via the new `apply_late_fees` function. A dedicated event is emitted each time fees are accrued.

Closes #50

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

> **Breaking change note:** Two new fields (`late_fees_outstanding`, `late_fee_accrual_timestamp`) were added to the `Loan` contracttype. Any client code constructing or deserialising `Loan` structs directly will need to be updated.

## Changes Made
- Added `late_fees_outstanding: i128` and `late_fee_accrual_timestamp: u64` to the `Loan` struct in `types.rs`
- Added constants `LATE_FEE_BPS_PER_DAY = 50` (0.5%/day) and `SECONDS_PER_DAY = 86_400` to `types.rs`
- Added `LOAN_LATE_FEE` event topic and `emit_late_fee_accrued(borrower, loan_id, fee_amount, new_remaining_balance)` to `events.rs`
- Added private `accrue_late_fees_internal` helper — finds the earliest overdue installment, counts only complete elapsed days (remainder carries over to the next accrual), updates `remaining_balance` and `late_fees_outstanding` in place
- Added public `apply_late_fees(loan_id)` — permissionless external trigger; no-op when nothing is due or the loan is not Active
- Updated `repay_loan` to lazily accrue late fees before validating the payment amount, extended the payment priority chain to `principal → interest → service fee → late fees`, and included `late_fee_paid` in the yield forwarded to the liquidity pool
- Initialised both new `Loan` fields to `0` in `build_loan`

## Testing
- [x] Tests pass locally
- [x] New tests added (if applicable)

8 new tests added in `creditline-contract/src/tests.rs`:

| Test | Scenario |
|---|---|
| `test_no_late_fee_before_due_date` | No fee when payment is on time |
| `test_apply_late_fees_adds_fee_after_one_day_overdue` | Correct fee after exactly 1 day overdue (5 tokens on a 1050 balance) |
| `test_apply_late_fees_accumulates_over_multiple_days` | 3 days overdue → 3× daily fee |
| `test_apply_late_fees_is_noop_within_same_day` | Double-call within same timestamp is idempotent |
| `test_apply_late_fees_incremental_across_two_calls` | Two separate calls each contribute one day |
| `test_apply_late_fees_on_paid_loan_fails` | Rejects with `LoanNotActive` on a closed loan |
| `test_repay_loan_auto_accrues_late_fees` | `repay_loan` triggers accrual; partial payment leaves late fees outstanding |
| `test_full_repayment_including_late_fees_sets_paid` | Paying full `remaining_balance` (incl. fees) closes the loan |
| `test_active_debt_includes_late_fees` | `get_user_active_debt` reflects accrued late fees |

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
