### PR TITLE
Feat/liquidity pool audit

### DIFF
--- a/contracts/creditline-contract/src/lib.rs
+++ b/contracts/creditline-contract/src/lib.rs
@@ -562,7 +562,13 @@ impl CreditLineContract {
         let accrued_fee = Self::accrue_late_fees_internal(&env, &mut loan);
         if accrued_fee > 0 {
             storage::increase_user_active_debt(&env, &borrower, accrued_fee);
-            events::emit_late_fee_accrued(&env, &borrower, loan_id, accrued_fee, loan.remaining_balance);
+            events::emit_late_fee_accrued(
+                &env,
+                &borrower,
+                loan_id,
+                accrued_fee,
+                loan.remaining_balance,
+            );
         }
 
         if amount <= 0 || amount > loan.remaining_balance {
@@ -778,7 +784,13 @@ impl CreditLineContract {
 
         storage::increase_user_active_debt(&env, &loan.borrower, accrued_fee);
         storage::write_loan(&env, &loan);
-        events::emit_late_fee_accrued(&env, &loan.borrower, loan_id, accrued_fee, loan.remaining_balance);
+        events::emit_late_fee_accrued(
+            &env,
+            &loan.borrower,
+            loan_id,
+            accrued_fee,
+            loan.remaining_balance,
+        );
     }
 
     fn handle_reputation_increase(

--- a/contracts/creditline-contract/src/tests.rs
+++ b/contracts/creditline-contract/src/tests.rs
@@ -2394,9 +2394,13 @@ fn test_no_late_fee_before_due_date() {
     let due_date = 50_000_u64;
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     let loan = t.client.get_loan(&loan_id);
     assert_eq!(loan.late_fees_outstanding, 0);
@@ -2415,9 +2419,13 @@ fn test_apply_late_fees_adds_fee_after_one_day_overdue() {
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     // Advance 1 full day past due_date
     t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
@@ -2441,9 +2449,13 @@ fn test_apply_late_fees_accumulates_over_multiple_days() {
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     t.env.ledger().set_timestamp(due_date + 3 * SECONDS_PER_DAY);
     t.client.apply_late_fees(&loan_id);
@@ -2465,9 +2477,13 @@ fn test_apply_late_fees_is_noop_within_same_day() {
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
     t.client.apply_late_fees(&loan_id);
@@ -2494,9 +2510,13 @@ fn test_apply_late_fees_incremental_across_two_calls() {
     // due_date == 0, so it's already overdue at creation time; first day starts at ledger 0
     // Advance ledger to 1 so due_date < now and create the loan
     t.env.ledger().set_timestamp(1);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     // First accrual: 1 day after due_date (due_date = 0, now = SECONDS_PER_DAY)
     t.env.ledger().set_timestamp(SECONDS_PER_DAY);
@@ -2542,9 +2562,13 @@ fn test_repay_loan_auto_accrues_late_fees() {
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     // Advance 1 day past due_date and attempt partial payment
     t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
@@ -2572,9 +2596,13 @@ fn test_full_repayment_including_late_fees_sets_paid() {
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     t.env.ledger().set_timestamp(due_date + SECONDS_PER_DAY);
     t.client.apply_late_fees(&loan_id);
@@ -2603,9 +2631,13 @@ fn test_active_debt_includes_late_fees() {
     let schedule = t.single_installment(DEFAULT_TOTAL_DUE, due_date);
     t.env.ledger().set_timestamp(0);
     t.mint(&user, DEFAULT_GUARANTEE);
-    let loan_id = t
-        .client
-        .create_loan(&user, &merchant, &DEFAULT_PRINCIPAL, &DEFAULT_GUARANTEE, &schedule);
+    let loan_id = t.client.create_loan(
+        &user,
+        &merchant,
+        &DEFAULT_PRINCIPAL,
+        &DEFAULT_GUARANTEE,
+        &schedule,
+    );
 
     let debt_before = t.client.get_user_active_debt(&user);
 
@@ -2731,8 +2763,7 @@ fn test_reputation_call_failure_does_not_block_repayment() {
     t.mint(&user, total_due);
 
     // Revoke updater permission so the increase_score call will fail
-    t.reputation
-        .set_updater(&t.admin, &t.creditline_id, &false);
+    t.reputation.set_updater(&t.admin, &t.creditline_id, &false);
 
     // Repayment must still succeed despite the reputation call failure
     t.creditline.repay_loan(&user, &loan_id, &total_due);

--- a/contracts/creditline-contract/src/types.rs
+++ b/contracts/creditline-contract/src/types.rs
@@ -38,10 +38,10 @@ pub struct Loan {
     pub remaining_balance: i128,
     pub repayment_schedule: soroban_sdk::Vec<RepaymentInstallment>,
     pub status: LoanStatus,
-    pub created_at: u64,                  // Unix timestamp
-    pub funded_at: u64,                   // 0 means not funded yet
-    pub late_fees_outstanding: i128,      // accumulated unpaid late fees
-    pub late_fee_accrual_timestamp: u64,  // last accrual timestamp (0 = never accrued)
+    pub created_at: u64,                 // Unix timestamp
+    pub funded_at: u64,                  // 0 means not funded yet
+    pub late_fees_outstanding: i128,     // accumulated unpaid late fees
+    pub late_fee_accrual_timestamp: u64, // last accrual timestamp (0 = never accrued)
 }
 
 pub fn default_protocol_parameters() -> ProtocolParameters {

--- a/contracts/liquidity-pool-contract/src/access.rs
+++ b/contracts/liquidity-pool-contract/src/access.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::{panic_with_error, Address, Env};
+
+use crate::{storage, LiquidityPoolError};
+
+pub fn require_admin(env: &Env, caller: &Address) {
+    let admin = storage::get_admin(env);
+    if admin != *caller {
+        panic_with_error!(env, LiquidityPoolError::NotAdmin);
+    }
+}
+
+pub fn require_creditline(env: &Env, caller: &Address) {
+    let creditline = storage::get_creditline(env)
+        .unwrap_or_else(|| panic_with_error!(env, LiquidityPoolError::NotCreditLine));
+    if creditline != *caller {
+        panic_with_error!(env, LiquidityPoolError::NotCreditLine);
+    }
+}

--- a/contracts/liquidity-pool-contract/src/errors.rs
+++ b/contracts/liquidity-pool-contract/src/errors.rs
@@ -15,4 +15,5 @@ pub enum LiquidityPoolError {
     NotCreditLine = 9,
     ZeroTotalShares = 10,
     ReentrancyDetected = 11,
+    ContractPaused = 12,
 }

--- a/contracts/liquidity-pool-contract/src/lib.rs
+++ b/contracts/liquidity-pool-contract/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env};
 
+mod access;
 mod errors;
 mod events;
 mod storage;
@@ -48,31 +49,46 @@ impl LiquidityPoolContract {
 
     pub fn set_creditline(env: Env, admin: Address, creditline: Address) {
         admin.require_auth();
-        Self::require_admin(&env, &admin);
+        access::require_admin(&env, &admin);
         storage::set_creditline(&env, &creditline);
     }
 
     pub fn set_treasury(env: Env, admin: Address, treasury: Address) {
         admin.require_auth();
-        Self::require_admin(&env, &admin);
+        access::require_admin(&env, &admin);
         storage::set_treasury(&env, &treasury);
     }
 
     pub fn set_merchant_fund(env: Env, admin: Address, merchant_fund: Address) {
         admin.require_auth();
-        Self::require_admin(&env, &admin);
+        access::require_admin(&env, &admin);
         storage::set_merchant_fund(&env, &merchant_fund);
     }
 
-    pub fn set_admin(env: Env, new_admin: Address) {
-        let old_admin = storage::get_admin(&env);
-        old_admin.require_auth();
-        Self::require_admin(&env, &old_admin);
+    pub fn set_admin(env: Env, admin: Address, new_admin: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
         storage::set_admin(&env, &new_admin);
     }
 
     pub fn get_admin(env: Env) -> Address {
         storage::get_admin(&env)
+    }
+
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+        storage::set_paused(&env, true);
+    }
+
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+        storage::set_paused(&env, false);
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        storage::is_paused(&env)
     }
 
     // -------------------------------------------------------------------------
@@ -87,8 +103,9 @@ impl LiquidityPoolContract {
     /// Returns the number of shares issued.
     pub fn deposit(env: Env, provider: Address, amount: i128) -> i128 {
         provider.require_auth();
+        Self::require_not_paused(&env);
 
-        if amount <= 0 {
+        if amount < types::MIN_AMOUNT {
             panic_with_error!(&env, LiquidityPoolError::InvalidAmount);
         }
 
@@ -119,6 +136,7 @@ impl LiquidityPoolContract {
             .checked_add(shares_issued)
             .unwrap_or_else(|| panic_with_error!(&env, LiquidityPoolError::Overflow));
         storage::set_lp_shares(&env, &provider, new_shares);
+        storage::bump_lp_shares(&env, &provider);
 
         let new_total_shares = total_shares
             .checked_add(shares_issued)
@@ -135,6 +153,7 @@ impl LiquidityPoolContract {
         token_client.transfer(&provider, &env.current_contract_address(), &amount);
 
         events::emit_liquidity_deposited(&env, &provider, amount, shares_issued);
+        storage::bump_instance(&env);
         Self::exit_non_reentrant(&env);
 
         shares_issued
@@ -147,6 +166,7 @@ impl LiquidityPoolContract {
     /// Returns the number of tokens returned.
     pub fn withdraw(env: Env, provider: Address, shares: i128) -> i128 {
         provider.require_auth();
+        Self::require_not_paused(&env);
 
         if shares <= 0 {
             panic_with_error!(&env, LiquidityPoolError::InvalidAmount);
@@ -185,6 +205,7 @@ impl LiquidityPoolContract {
             .checked_sub(shares)
             .unwrap_or_else(|| panic_with_error!(&env, LiquidityPoolError::Underflow));
         storage::set_lp_shares(&env, &provider, new_provider_shares);
+        storage::bump_lp_shares(&env, &provider);
 
         let new_total_shares = total_shares
             .checked_sub(shares)
@@ -201,6 +222,7 @@ impl LiquidityPoolContract {
         let token = storage::get_token(&env);
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&env.current_contract_address(), &provider, &amount_returned);
+        storage::bump_instance(&env);
         Self::exit_non_reentrant(&env);
 
         amount_returned
@@ -214,7 +236,8 @@ impl LiquidityPoolContract {
     /// Only the registered CreditLine contract may call this.
     pub fn fund_loan(env: Env, creditline: Address, merchant: Address, amount: i128) {
         creditline.require_auth();
-        Self::require_creditline(&env, &creditline);
+        access::require_creditline(&env, &creditline);
+        Self::require_not_paused(&env);
 
         if amount <= 0 {
             panic_with_error!(&env, LiquidityPoolError::InvalidAmount);
@@ -252,7 +275,8 @@ impl LiquidityPoolContract {
     /// `interest`  is distributed via `distribute_interest` (increases pool value).
     pub fn receive_repayment(env: Env, creditline: Address, principal: i128, interest: i128) {
         creditline.require_auth();
-        Self::require_creditline(&env, &creditline);
+        access::require_creditline(&env, &creditline);
+        Self::require_not_paused(&env);
 
         if principal < 0 || interest < 0 {
             panic_with_error!(&env, LiquidityPoolError::InvalidAmount);
@@ -292,7 +316,8 @@ impl LiquidityPoolContract {
     /// and reduces locked_liquidity by the same amount (partial recovery).
     pub fn receive_guarantee(env: Env, creditline: Address, amount: i128) {
         creditline.require_auth();
-        Self::require_creditline(&env, &creditline);
+        access::require_creditline(&env, &creditline);
+        Self::require_not_paused(&env);
 
         if amount <= 0 {
             panic_with_error!(&env, LiquidityPoolError::InvalidAmount);
@@ -317,9 +342,10 @@ impl LiquidityPoolContract {
 
         let token = storage::get_token(&env);
         let token_client = token::Client::new(&env, &token);
-        token_client.transfer(&creditline, &env.current_contract_address(), &amount);
+        // Transfer only the recovered amount — keeps accounting consistent (H-3).
+        token_client.transfer(&creditline, &env.current_contract_address(), &recovered);
 
-        events::emit_guarantee_received(&env, &creditline, amount);
+        events::emit_guarantee_received(&env, &creditline, recovered);
         Self::exit_non_reentrant(&env);
     }
 
@@ -327,20 +353,18 @@ impl LiquidityPoolContract {
     // Interest Distribution (SC-17 core feature)
     // -------------------------------------------------------------------------
 
-    /// Distribute `interest_amount` according to the protocol fee split:
-    ///   - 85 % → Liquidity Providers  (increases share value by raising `total_liquidity`)
-    ///   - 10 % → Protocol Treasury
-    ///   -  5 % → Merchant Incentive Fund
-    ///
-    /// The LP portion is NOT transferred out; it stays in the pool and inflates
-    /// the share price (existing LP shares become worth more).
-    ///
-    /// This function is called internally by `receive_repayment`, but it is also
-    /// `pub` so that the CreditLine (or admin, in edge-case) can call it directly.
-    pub fn distribute_interest(env: &Env, interest_amount: i128) {
-        Self::enter_non_reentrant(env);
-        Self::distribute_interest_internal(env, interest_amount);
-        Self::exit_non_reentrant(env);
+    /// Distribute interest. Only the registered CreditLine or admin may call this.
+    pub fn distribute_interest(env: Env, caller: Address, interest_amount: i128) {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+        let is_admin = storage::get_admin(&env) == caller;
+        let is_creditline = storage::get_creditline(&env).map_or(false, |cl| cl == caller);
+        if !is_admin && !is_creditline {
+            panic_with_error!(&env, LiquidityPoolError::NotCreditLine);
+        }
+        Self::enter_non_reentrant(&env);
+        Self::distribute_interest_internal(&env, interest_amount);
+        Self::exit_non_reentrant(&env);
     }
 
     fn distribute_interest_internal(env: &Env, interest_amount: i128) {
@@ -436,6 +460,7 @@ impl LiquidityPoolContract {
     }
 
     pub fn get_lp_shares(env: Env, provider: Address) -> i128 {
+        storage::bump_lp_shares(&env, &provider);
         storage::get_lp_shares(&env, &provider)
     }
 
@@ -452,22 +477,29 @@ impl LiquidityPoolContract {
             .unwrap_or(0)
     }
 
+    pub fn get_token(env: Env) -> Address {
+        storage::get_token(&env)
+    }
+
+    pub fn get_treasury(env: Env) -> Option<Address> {
+        storage::get_treasury(&env)
+    }
+
+    pub fn get_merchant_fund(env: Env) -> Option<Address> {
+        storage::get_merchant_fund(&env)
+    }
+
+    pub fn get_creditline(env: Env) -> Option<Address> {
+        storage::get_creditline(&env)
+    }
+
     // -------------------------------------------------------------------------
     // Internal helpers
     // -------------------------------------------------------------------------
 
-    fn require_admin(env: &Env, caller: &Address) {
-        let admin = storage::get_admin(env);
-        if admin != *caller {
-            panic_with_error!(env, LiquidityPoolError::NotAdmin);
-        }
-    }
-
-    fn require_creditline(env: &Env, caller: &Address) {
-        let creditline = storage::get_creditline(env)
-            .unwrap_or_else(|| panic_with_error!(env, LiquidityPoolError::NotCreditLine));
-        if creditline != *caller {
-            panic_with_error!(env, LiquidityPoolError::NotCreditLine);
+    fn require_not_paused(env: &Env) {
+        if storage::is_paused(env) {
+            panic_with_error!(env, LiquidityPoolError::ContractPaused);
         }
     }
 

--- a/contracts/liquidity-pool-contract/src/storage.rs
+++ b/contracts/liquidity-pool-contract/src/storage.rs
@@ -35,7 +35,6 @@ pub fn bump_lp_shares(env: &Env, provider: &Address) {
     );
 }
 
-
 // --- Admin ---
 
 pub fn get_admin(env: &Env) -> Address {
@@ -161,10 +160,7 @@ pub fn set_reentrancy_locked(env: &Env, locked: bool) {
 }
 
 pub fn is_paused(env: &Env) -> bool {
-    env.storage()
-        .instance()
-        .get(&PAUSED_KEY)
-        .unwrap_or(false)
+    env.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
 }
 
 pub fn set_paused(env: &Env, paused: bool) {

--- a/contracts/liquidity-pool-contract/src/storage.rs
+++ b/contracts/liquidity-pool-contract/src/storage.rs
@@ -10,9 +10,31 @@ pub const CREDITLINE_KEY: Symbol = symbol_short!("CRDTLIN");
 pub const TREASURY_KEY: Symbol = symbol_short!("TREASURY");
 pub const MERCHANT_FUND_KEY: Symbol = symbol_short!("MRCHFND");
 pub const REENTRANCY_LOCK_KEY: Symbol = symbol_short!("LOCKED");
+pub const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 
 // Persistent storage key prefix for LP shares
 pub const LP_SHARES_PREFIX: Symbol = symbol_short!("LPSHRS");
+
+// TTL constants (~30 days at 5 s/ledger)
+const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 259_200;
+const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 259_200;
+
+pub fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+pub fn bump_lp_shares(env: &Env, provider: &Address) {
+    env.storage().persistent().extend_ttl(
+        &(LP_SHARES_PREFIX, provider.clone()),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
 
 // --- Admin ---
 
@@ -136,4 +158,15 @@ pub fn is_reentrancy_locked(env: &Env) -> bool {
 
 pub fn set_reentrancy_locked(env: &Env, locked: bool) {
     env.storage().instance().set(&REENTRANCY_LOCK_KEY, &locked);
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&PAUSED_KEY)
+        .unwrap_or(false)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&PAUSED_KEY, &paused);
 }

--- a/contracts/liquidity-pool-contract/src/tests.rs
+++ b/contracts/liquidity-pool-contract/src/tests.rs
@@ -68,7 +68,6 @@ impl TestEnv {
     }
 }
 
-
 // ─── initialization ───────────────────────────────────────────────────────────
 
 #[test]
@@ -976,7 +975,9 @@ fn test_withdrawal_with_active_loans_exceeds_available_shares() {
     context
         .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
-    context.client().withdraw(&provider, &first_withdrawal_shares);
+    context
+        .client()
+        .withdraw(&provider, &first_withdrawal_shares);
 
     // Now provider has 400 shares remaining, but available_liquidity is 0
     // Attempt to withdraw 500 shares (more than remaining) - should fail with InsufficientShares
@@ -1005,7 +1006,9 @@ fn test_withdrawal_with_active_loans_no_available_liquidity() {
     context
         .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
-    context.client().withdraw(&provider, &first_withdrawal_shares);
+    context
+        .client()
+        .withdraw(&provider, &first_withdrawal_shares);
 
     // Now provider has 400 shares remaining, but available_liquidity is 0
     // Attempt to withdraw any amount when available_liquidity is 0 - should fail
@@ -1207,7 +1210,9 @@ fn test_share_value_appreciation_over_time() {
     // 6. Test that new depositors after interest get fewer shares per token
     let new_provider = Address::generate(&context.env);
     context.mint(&new_provider, new_provider_deposit);
-    let new_shares = context.client().deposit(&new_provider, &new_provider_deposit);
+    let new_shares = context
+        .client()
+        .deposit(&new_provider, &new_provider_deposit);
     // With empty pool, first deposit gets 1:1 ratio again
     assert_eq!(new_shares, expected_new_provider_shares);
 }

--- a/contracts/liquidity-pool-contract/src/tests.rs
+++ b/contracts/liquidity-pool-contract/src/tests.rs
@@ -9,8 +9,8 @@ use soroban_sdk::{
 
 struct TestEnv {
     env: Env,
-    client: LiquidityPoolContractClient<'static>,
-    token: TokenClient<'static>,
+    contract_id: Address,
+    token_address: Address,
     admin: Address,
     treasury: Address,
     merchant_fund: Address,
@@ -22,23 +22,13 @@ impl TestEnv {
         let env = Env::default();
         env.mock_all_auths();
 
-        // Deploy a Stellar asset (test token)
         let token_admin = Address::generate(&env);
         let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone());
         let token_address = token_contract_id.address();
 
-        let token = TokenClient::new(&env, &token_address);
         let token_sac = StellarAssetClient::new(&env, &token_address);
-
-        // Deploy liquidity pool contract
         let contract_id = env.register(LiquidityPoolContract, ());
         let client = LiquidityPoolContractClient::new(&env, &contract_id);
-
-        // SAFETY: we extend the lifetime so we can store these in the struct.
-        // This is safe because `env` outlives both clients.
-        let token: TokenClient<'static> = unsafe { core::mem::transmute(token) };
-        let token_sac: StellarAssetClient<'static> = unsafe { core::mem::transmute(token_sac) };
-        let client: LiquidityPoolContractClient<'static> = unsafe { core::mem::transmute(client) };
 
         let admin = Address::generate(&env);
         let treasury = Address::generate(&env);
@@ -54,8 +44,8 @@ impl TestEnv {
 
         Self {
             env,
-            client,
-            token,
+            contract_id,
+            token_address,
             admin,
             treasury,
             merchant_fund,
@@ -63,20 +53,28 @@ impl TestEnv {
         }
     }
 
+    fn client(&self) -> LiquidityPoolContractClient<'_> {
+        LiquidityPoolContractClient::new(&self.env, &self.contract_id)
+    }
+
+    fn token(&self) -> TokenClient<'_> {
+        TokenClient::new(&self.env, &self.token_address)
+    }
+
     /// Mint `amount` tokens to `recipient`
     fn mint(&self, recipient: &Address, amount: i128) {
-        let token_address = self.token.address.clone();
-        let token_sac = StellarAssetClient::new(&self.env, &token_address);
+        let token_sac = StellarAssetClient::new(&self.env, &self.token_address);
         token_sac.mint(recipient, &amount);
     }
 }
+
 
 // ─── initialization ───────────────────────────────────────────────────────────
 
 #[test]
 fn test_initialize() {
     let t = TestEnv::setup();
-    assert_eq!(t.client.get_admin(), t.admin);
+    assert_eq!(t.client().get_admin(), t.admin);
 }
 
 #[test]
@@ -85,9 +83,9 @@ fn test_initialize_twice_fails() {
     let t = TestEnv::setup();
     // Second call should panic with AlreadyInitialized (2)
     let another_admin = Address::generate(&t.env);
-    t.client.initialize(
+    t.client().initialize(
         &another_admin,
-        &t.token.address,
+        &t.token().address,
         &t.treasury,
         &t.merchant_fund,
     );
@@ -101,13 +99,13 @@ fn test_first_deposit_one_to_one_ratio() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
 
-    let shares = t.client.deposit(&provider, &1_000);
+    let shares = t.client().deposit(&provider, &1_000);
 
     // First deposit → shares == amount
     assert_eq!(shares, 1_000);
-    assert_eq!(t.client.get_lp_shares(&provider), 1_000);
+    assert_eq!(t.client().get_lp_shares(&provider), 1_000);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 1_000);
     assert_eq!(stats.total_shares, 1_000);
     assert_eq!(stats.locked_liquidity, 0);
@@ -124,13 +122,13 @@ fn test_subsequent_deposit_proportional_shares() {
     t.mint(&provider_b, 1_000);
 
     // First deposit
-    t.client.deposit(&provider_a, &1_000);
+    t.client().deposit(&provider_a, &1_000);
 
     // Second deposit: same amount → same shares (pool value unchanged)
-    let shares_b = t.client.deposit(&provider_b, &1_000);
+    let shares_b = t.client().deposit(&provider_b, &1_000);
     assert_eq!(shares_b, 1_000);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 2_000);
     assert_eq!(stats.total_shares, 2_000);
 }
@@ -147,7 +145,7 @@ fn test_deposit_after_interest_increases_share_value() {
     t.mint(&provider_b, 1_000);
 
     // First deposit: 1000 tokens → 1000 shares
-    t.client.deposit(&provider_a, &1_000);
+    t.client().deposit(&provider_a, &1_000);
 
     // Simulate interest: distribute 100 tokens of interest.
     // 85 stays in pool → total_liquidity becomes 1085, total_shares stays 1000.
@@ -156,19 +154,19 @@ fn test_deposit_after_interest_increases_share_value() {
     // We inject interest by sending tokens to the pool and calling receive_repayment
     // with principal=0, interest=100.
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
     // Now total_liquidity includes the LP portion (85) of interest.
     // Pool: total_liquidity = 1000 + 85 = 1085, total_shares = 1000
     // Second deposit of 1000 tokens: shares = 1000 * 1000 / 1085 ≈ 921
-    let shares_b = t.client.deposit(&provider_b, &1_000);
+    let shares_b = t.client().deposit(&provider_b, &1_000);
     assert!(
         shares_b < 1_000,
         "Shares must be < 1000 since pool value grew"
     );
 
     // provider_a's shares are still 1000 but worth more
-    assert_eq!(t.client.get_lp_shares(&provider_a), 1_000);
+    assert_eq!(t.client().get_lp_shares(&provider_a), 1_000);
 }
 
 #[test]
@@ -176,7 +174,7 @@ fn test_deposit_after_interest_increases_share_value() {
 fn test_deposit_zero_amount_fails() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
-    t.client.deposit(&provider, &0);
+    t.client().deposit(&provider, &0);
 }
 
 #[test]
@@ -184,7 +182,7 @@ fn test_deposit_zero_amount_fails() {
 fn test_deposit_negative_amount_fails() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
-    t.client.deposit(&provider, &-500);
+    t.client().deposit(&provider, &-500);
 }
 
 // ─── withdraw ─────────────────────────────────────────────────────────────────
@@ -195,13 +193,13 @@ fn test_full_withdrawal() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
 
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
-    let amount_returned = t.client.withdraw(&provider, &1_000);
+    let amount_returned = t.client().withdraw(&provider, &1_000);
     assert_eq!(amount_returned, 1_000);
-    assert_eq!(t.client.get_lp_shares(&provider), 0);
+    assert_eq!(t.client().get_lp_shares(&provider), 0);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 0);
     assert_eq!(stats.total_shares, 0);
 }
@@ -212,13 +210,13 @@ fn test_partial_withdrawal() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
 
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
-    let amount_returned = t.client.withdraw(&provider, &400);
+    let amount_returned = t.client().withdraw(&provider, &400);
     assert_eq!(amount_returned, 400);
-    assert_eq!(t.client.get_lp_shares(&provider), 600);
+    assert_eq!(t.client().get_lp_shares(&provider), 600);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 600);
     assert_eq!(stats.total_shares, 600);
 }
@@ -230,15 +228,15 @@ fn test_withdrawal_reflects_share_appreciation() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
 
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Distribute 100 interest (85 stays in pool)
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
     // Total_liquidity = 1085, total_shares = 1000
     // Withdraw all 1000 shares → should receive 1085 tokens
-    let amount_returned = t.client.withdraw(&provider, &1_000);
+    let amount_returned = t.client().withdraw(&provider, &1_000);
     assert_eq!(amount_returned, 1_085);
 }
 
@@ -248,8 +246,8 @@ fn test_withdraw_more_shares_than_owned_fails() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
-    t.client.withdraw(&provider, &1_001);
+    t.client().deposit(&provider, &1_000);
+    t.client().withdraw(&provider, &1_001);
 }
 
 #[test]
@@ -259,13 +257,13 @@ fn test_withdraw_when_liquidity_locked_fails() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Lock all liquidity in a loan
-    t.client.fund_loan(&t.creditline, &merchant, &1_000);
+    t.client().fund_loan(&t.creditline, &merchant, &1_000);
 
     // Try to withdraw → all liquidity is locked
-    t.client.withdraw(&provider, &1_000);
+    t.client().withdraw(&provider, &1_000);
 }
 
 #[test]
@@ -273,7 +271,7 @@ fn test_withdraw_when_liquidity_locked_fails() {
 fn test_withdraw_zero_shares_fails() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
-    t.client.withdraw(&provider, &0);
+    t.client().withdraw(&provider, &0);
 }
 
 // ─── fund_loan ────────────────────────────────────────────────────────────────
@@ -284,11 +282,11 @@ fn test_fund_loan_increases_locked_liquidity() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
-    t.client.fund_loan(&t.creditline, &merchant, &400);
+    t.client().fund_loan(&t.creditline, &merchant, &400);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.locked_liquidity, 400);
     assert_eq!(stats.available_liquidity, 600);
     assert_eq!(stats.total_liquidity, 1_000);
@@ -301,10 +299,10 @@ fn test_fund_loan_exceeds_available_fails() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Try to fund more than available
-    t.client.fund_loan(&t.creditline, &merchant, &1_001);
+    t.client().fund_loan(&t.creditline, &merchant, &1_001);
 }
 
 #[test]
@@ -313,7 +311,7 @@ fn test_fund_loan_unauthorized_caller_fails() {
     let t = TestEnv::setup();
     let intruder = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
-    t.client.fund_loan(&intruder, &merchant, &100);
+    t.client().fund_loan(&intruder, &merchant, &100);
 }
 
 // ─── receive_repayment ────────────────────────────────────────────────────────
@@ -324,16 +322,16 @@ fn test_receive_repayment_decreases_locked_and_distributes_interest() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Fund a 400-token loan
-    t.client.fund_loan(&t.creditline, &merchant, &400);
+    t.client().fund_loan(&t.creditline, &merchant, &400);
 
     // Repay 400 principal + 40 interest
     t.mint(&t.creditline, 440);
-    t.client.receive_repayment(&t.creditline, &400, &40);
+    t.client().receive_repayment(&t.creditline, &400, &40);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.locked_liquidity, 0);
 
     // fund_loan does NOT reduce total_liquidity — only moves tokens into locked.
@@ -347,14 +345,14 @@ fn test_receive_repayment_treasury_receives_protocol_fee() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Send 100 interest
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
     // Treasury gets 10% = 10
-    let treasury_balance = t.token.balance(&t.treasury);
+    let treasury_balance = t.token().balance(&t.treasury);
     assert_eq!(treasury_balance, 10);
 }
 
@@ -363,14 +361,14 @@ fn test_receive_repayment_merchant_fund_receives_fee() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Send 100 interest
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
     // Merchant fund gets 5% = 5
-    let mf_balance = t.token.balance(&t.merchant_fund);
+    let mf_balance = t.token().balance(&t.merchant_fund);
     assert_eq!(mf_balance, 5);
 }
 
@@ -383,31 +381,31 @@ fn test_double_counting_does_not_compound_across_multiple_loan_cycles() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Cycle 1
-    t.client.fund_loan(&t.creditline, &merchant, &600);
+    t.client().fund_loan(&t.creditline, &merchant, &600);
     t.mint(&t.creditline, 600);
-    t.client.receive_repayment(&t.creditline, &600, &0);
+    t.client().receive_repayment(&t.creditline, &600, &0);
 
-    assert_eq!(t.client.get_pool_stats().total_liquidity, 1_000);
+    assert_eq!(t.client().get_pool_stats().total_liquidity, 1_000);
 
     // Cycle 2
-    t.client.fund_loan(&t.creditline, &merchant, &600);
+    t.client().fund_loan(&t.creditline, &merchant, &600);
     t.mint(&t.creditline, 600);
-    t.client.receive_repayment(&t.creditline, &600, &0);
+    t.client().receive_repayment(&t.creditline, &600, &0);
 
-    assert_eq!(t.client.get_pool_stats().total_liquidity, 1_000);
+    assert_eq!(t.client().get_pool_stats().total_liquidity, 1_000);
 
     // Cycle 3
-    t.client.fund_loan(&t.creditline, &merchant, &600);
+    t.client().fund_loan(&t.creditline, &merchant, &600);
     t.mint(&t.creditline, 600);
-    t.client.receive_repayment(&t.creditline, &600, &0);
+    t.client().receive_repayment(&t.creditline, &600, &0);
 
-    assert_eq!(t.client.get_pool_stats().total_liquidity, 1_000);
+    assert_eq!(t.client().get_pool_stats().total_liquidity, 1_000);
 
     // Provider must be able to withdraw their full original deposit
-    let returned = t.client.withdraw(&provider, &1_000);
+    let returned = t.client().withdraw(&provider, &1_000);
     assert_eq!(returned, 1_000);
 }
 
@@ -419,20 +417,20 @@ fn test_distribute_interest_fee_split_accuracy() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 10_000);
-    t.client.deposit(&provider, &10_000);
+    t.client().deposit(&provider, &10_000);
 
     t.mint(&t.creditline, 1_000);
-    t.client.receive_repayment(&t.creditline, &0, &1_000);
+    t.client().receive_repayment(&t.creditline, &0, &1_000);
 
     // LP: 850 stays in pool → total_liquidity = 10000 + 850 = 10850
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 10_850);
 
     // Treasury: 10% = 100
-    assert_eq!(t.token.balance(&t.treasury), 100);
+    assert_eq!(t.token().balance(&t.treasury), 100);
 
     // Merchant fund: 5% = 50
-    assert_eq!(t.token.balance(&t.merchant_fund), 50);
+    assert_eq!(t.token().balance(&t.merchant_fund), 50);
 }
 
 #[test]
@@ -444,16 +442,16 @@ fn test_distribute_interest_share_value_appreciation() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
-    let stats_before = t.client.get_pool_stats();
+    let stats_before = t.client().get_pool_stats();
     assert_eq!(stats_before.share_price, 10_000); // $1.00 in bps
 
     // Distribute 80 tokens of interest (8% on 1000)
     t.mint(&t.creditline, 80);
-    t.client.receive_repayment(&t.creditline, &0, &80);
+    t.client().receive_repayment(&t.creditline, &0, &80);
 
-    let stats_after = t.client.get_pool_stats();
+    let stats_after = t.client().get_pool_stats();
     // lp_amount = 80 * 8500 / 10000 = 68
     assert_eq!(stats_after.total_liquidity, 1_068);
     assert_eq!(stats_after.share_price, 10_680); // $1.068 expressed as bps
@@ -470,22 +468,22 @@ fn test_multiple_lp_proportional_distribution() {
     t.mint(&provider_a, 1_000);
     t.mint(&provider_b, 1_000);
 
-    t.client.deposit(&provider_a, &1_000);
-    t.client.deposit(&provider_b, &1_000);
+    t.client().deposit(&provider_a, &1_000);
+    t.client().deposit(&provider_b, &1_000);
 
     // 200 interest distributed (100 per LP proportionally)
     t.mint(&t.creditline, 200);
-    t.client.receive_repayment(&t.creditline, &0, &200);
+    t.client().receive_repayment(&t.creditline, &0, &200);
 
     // LP amount = 85% of 200 = 170 → added to pool
     // total_liquidity = 2000 + 170 = 2170, total_shares = 2000
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 2_170);
 
     // Both LPs hold 1000 shares out of 2000 → each owns 50% of pool
     // Withdrawal value per LP = 1000 * 2170 / 2000 = 1085
-    let val_a = t.client.calculate_withdrawal(&1_000);
-    let val_b = t.client.calculate_withdrawal(&1_000);
+    let val_a = t.client().calculate_withdrawal(&1_000);
+    let val_b = t.client().calculate_withdrawal(&1_000);
     assert_eq!(val_a, 1_085);
     assert_eq!(val_b, 1_085);
 }
@@ -496,15 +494,15 @@ fn test_interest_calculation_accuracy_small_amount() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
-    assert_eq!(t.token.balance(&t.treasury), 10);
-    assert_eq!(t.token.balance(&t.merchant_fund), 5);
+    assert_eq!(t.token().balance(&t.treasury), 10);
+    assert_eq!(t.token().balance(&t.merchant_fund), 5);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 1_085);
 }
 
@@ -517,13 +515,13 @@ fn test_interest_rounding_remainder_goes_to_lp() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 10_000);
-    t.client.deposit(&provider, &10_000);
+    t.client().deposit(&provider, &10_000);
 
     t.mint(&t.creditline, 101);
-    t.client.receive_repayment(&t.creditline, &0, &101);
+    t.client().receive_repayment(&t.creditline, &0, &101);
 
-    assert_eq!(t.token.balance(&t.treasury), 10);
-    assert_eq!(t.token.balance(&t.merchant_fund), 6); // remainder goes here
+    assert_eq!(t.token().balance(&t.treasury), 10);
+    assert_eq!(t.token().balance(&t.merchant_fund), 6); // remainder goes here
 }
 
 // ─── receive_guarantee ────────────────────────────────────────────────────────
@@ -534,16 +532,16 @@ fn test_receive_guarantee_reduces_locked_and_recovers_liquidity() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Fund a 500-token loan
-    t.client.fund_loan(&t.creditline, &merchant, &500);
+    t.client().fund_loan(&t.creditline, &merchant, &500);
 
     // Default: guarantee of 100 returned
     t.mint(&t.creditline, 100);
-    t.client.receive_guarantee(&t.creditline, &100);
+    t.client().receive_guarantee(&t.creditline, &100);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     // locked was 500, reduced by 100 → 400
     assert_eq!(stats.locked_liquidity, 400);
     // total_liquidity was 1000, recovered 100 → 1100... no wait:
@@ -562,11 +560,11 @@ fn test_withdraw_returns_tokens_to_provider() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 2_000);
 
-    t.client.deposit(&provider, &2_000);
-    assert_eq!(t.token.balance(&provider), 0);
+    t.client().deposit(&provider, &2_000);
+    assert_eq!(t.token().balance(&provider), 0);
 
-    t.client.withdraw(&provider, &2_000);
-    assert_eq!(t.token.balance(&provider), 2_000);
+    t.client().withdraw(&provider, &2_000);
+    assert_eq!(t.token().balance(&provider), 2_000);
 }
 
 #[test]
@@ -576,10 +574,10 @@ fn test_withdraw_updates_pool_stats_correctly() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 3_000);
 
-    t.client.deposit(&provider, &3_000);
-    t.client.withdraw(&provider, &1_000);
+    t.client().deposit(&provider, &3_000);
+    t.client().withdraw(&provider, &1_000);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 2_000);
     assert_eq!(stats.total_shares, 2_000);
     assert_eq!(stats.locked_liquidity, 0);
@@ -596,25 +594,25 @@ fn test_two_providers_independent_withdrawals() {
     t.mint(&provider_a, 1_000);
     t.mint(&provider_b, 2_000);
 
-    t.client.deposit(&provider_a, &1_000);
-    t.client.deposit(&provider_b, &2_000);
+    t.client().deposit(&provider_a, &1_000);
+    t.client().deposit(&provider_b, &2_000);
 
     // A withdraws all their shares (1000 out of 3000 total = 1/3 of pool)
-    let returned_a = t.client.withdraw(&provider_a, &1_000);
+    let returned_a = t.client().withdraw(&provider_a, &1_000);
     assert_eq!(returned_a, 1_000);
-    assert_eq!(t.client.get_lp_shares(&provider_a), 0);
+    assert_eq!(t.client().get_lp_shares(&provider_a), 0);
 
     // B's shares and pool value are intact
-    assert_eq!(t.client.get_lp_shares(&provider_b), 2_000);
-    let stats = t.client.get_pool_stats();
+    assert_eq!(t.client().get_lp_shares(&provider_b), 2_000);
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 2_000);
     assert_eq!(stats.total_shares, 2_000);
 
     // B withdraws everything
-    let returned_b = t.client.withdraw(&provider_b, &2_000);
+    let returned_b = t.client().withdraw(&provider_b, &2_000);
     assert_eq!(returned_b, 2_000);
 
-    let stats_final = t.client.get_pool_stats();
+    let stats_final = t.client().get_pool_stats();
     assert_eq!(stats_final.total_liquidity, 0);
     assert_eq!(stats_final.total_shares, 0);
 }
@@ -627,17 +625,17 @@ fn test_withdraw_partial_when_some_liquidity_locked() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Lock 400 tokens in a loan → 600 available
-    t.client.fund_loan(&t.creditline, &merchant, &400);
+    t.client().fund_loan(&t.creditline, &merchant, &400);
 
     // Withdraw shares worth exactly 600 tokens (should pass)
     // shares_to_withdraw = 600 * 1000 / 1000 = 600 shares
-    let returned = t.client.withdraw(&provider, &600);
+    let returned = t.client().withdraw(&provider, &600);
     assert_eq!(returned, 600);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 400);
     assert_eq!(stats.locked_liquidity, 400);
     assert_eq!(stats.available_liquidity, 0);
@@ -649,8 +647,8 @@ fn test_withdraw_negative_shares_fails() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
-    t.client.withdraw(&provider, &-1);
+    t.client().deposit(&provider, &1_000);
+    t.client().withdraw(&provider, &-1);
 }
 
 #[test]
@@ -660,16 +658,16 @@ fn test_sequential_partial_withdrawals_drain_pool() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
 
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
-    let first = t.client.withdraw(&provider, &600);
+    let first = t.client().withdraw(&provider, &600);
     assert_eq!(first, 600);
 
-    let second = t.client.withdraw(&provider, &400);
+    let second = t.client().withdraw(&provider, &400);
     assert_eq!(second, 400);
 
-    assert_eq!(t.client.get_lp_shares(&provider), 0);
-    let stats = t.client.get_pool_stats();
+    assert_eq!(t.client().get_lp_shares(&provider), 0);
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 0);
     assert_eq!(stats.total_shares, 0);
 }
@@ -688,22 +686,22 @@ fn test_withdraw_succeeds_after_loan_repayment_unlocks_liquidity() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Lock 600 tokens — only 400 remain available; a 1000-share withdrawal
     // (worth 1000 tokens) would exceed available_liquidity and fail.
-    t.client.fund_loan(&t.creditline, &merchant, &600);
+    t.client().fund_loan(&t.creditline, &merchant, &600);
 
-    let stats_mid = t.client.get_pool_stats();
+    let stats_mid = t.client().get_pool_stats();
     assert_eq!(stats_mid.locked_liquidity, 600);
     assert_eq!(stats_mid.available_liquidity, 400);
 
     // Creditline repays 600 principal (no interest).
     t.mint(&t.creditline, 600);
-    t.client.receive_repayment(&t.creditline, &600, &0);
+    t.client().receive_repayment(&t.creditline, &600, &0);
 
     // Locked must be zero; all liquidity available.
-    let stats_after = t.client.get_pool_stats();
+    let stats_after = t.client().get_pool_stats();
     assert_eq!(stats_after.locked_liquidity, 0);
     assert_eq!(stats_after.available_liquidity, stats_after.total_liquidity);
 
@@ -712,9 +710,9 @@ fn test_withdraw_succeeds_after_loan_repayment_unlocks_liquidity() {
     //                           and receive_repayment no longer adds principal back)
     //   total_shares    = 1000
     // Withdrawing 600 shares: 600 * 1000 / 1000 = 600 tokens.
-    let returned = t.client.withdraw(&provider, &600);
+    let returned = t.client().withdraw(&provider, &600);
     assert_eq!(returned, 600);
-    assert_eq!(t.client.get_lp_shares(&provider), 400);
+    assert_eq!(t.client().get_lp_shares(&provider), 400);
 }
 
 // ─── pool_stats & calculate_withdrawal ───────────────────────────────────────
@@ -722,7 +720,7 @@ fn test_withdraw_succeeds_after_loan_repayment_unlocks_liquidity() {
 #[test]
 fn test_get_pool_stats_empty_pool() {
     let t = TestEnv::setup();
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, 0);
     assert_eq!(stats.total_shares, 0);
     assert_eq!(stats.locked_liquidity, 0);
@@ -733,7 +731,7 @@ fn test_get_pool_stats_empty_pool() {
 #[test]
 fn test_calculate_withdrawal_empty_pool_returns_zero() {
     let t = TestEnv::setup();
-    assert_eq!(t.client.calculate_withdrawal(&1_000), 0);
+    assert_eq!(t.client().calculate_withdrawal(&1_000), 0);
 }
 
 // ─── admin operations ─────────────────────────────────────────────────────────
@@ -742,8 +740,8 @@ fn test_calculate_withdrawal_empty_pool_returns_zero() {
 fn test_set_admin() {
     let t = TestEnv::setup();
     let new_admin = Address::generate(&t.env);
-    t.client.set_admin(&new_admin);
-    assert_eq!(t.client.get_admin(), new_admin);
+    t.client().set_admin(&t.admin, &new_admin);
+    assert_eq!(t.client().get_admin(), new_admin);
 }
 
 #[test]
@@ -752,7 +750,7 @@ fn test_non_admin_cannot_set_creditline() {
     let t = TestEnv::setup();
     let intruder = Address::generate(&t.env);
     let new_creditline = Address::generate(&t.env);
-    t.client.set_creditline(&intruder, &new_creditline);
+    t.client().set_creditline(&intruder, &new_creditline);
 }
 
 #[test]
@@ -777,17 +775,17 @@ fn test_share_calculation_accuracy() {
     // 1. Test with various deposit amounts (small, medium, large)
     let provider1 = Address::generate(&context.env);
     context.mint(&provider1, provider1_deposit);
-    let shares1 = context.client.deposit(&provider1, &provider1_deposit);
+    let shares1 = context.client().deposit(&provider1, &provider1_deposit);
     assert_eq!(shares1, provider1_expected_shares);
 
     // 2. Test with different pool states - second deposit (proportional)
     let provider2 = Address::generate(&context.env);
     context.mint(&provider2, provider2_deposit);
-    let shares2 = context.client.deposit(&provider2, &provider2_deposit);
+    let shares2 = context.client().deposit(&provider2, &provider2_deposit);
     assert_eq!(shares2, provider2_expected_shares);
 
     // 3. Verify no precision loss - total should match
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_shares, expected_total_shares);
     assert_eq!(stats.total_liquidity, expected_total_liquidity);
 
@@ -795,10 +793,10 @@ fn test_share_calculation_accuracy() {
     // Simulate interest distribution
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
-    let stats_after = context.client.get_pool_stats();
+    let stats_after = context.client().get_pool_stats();
     assert_eq!(
         stats_after.total_liquidity,
         expected_liquidity_after_interest
@@ -807,7 +805,7 @@ fn test_share_calculation_accuracy() {
     // Small deposit should round down correctly
     let provider3 = Address::generate(&context.env);
     context.mint(&provider3, provider3_deposit);
-    let shares3 = context.client.deposit(&provider3, &provider3_deposit);
+    let shares3 = context.client().deposit(&provider3, &provider3_deposit);
     assert_eq!(shares3, provider3_expected_shares);
 }
 
@@ -837,28 +835,28 @@ fn test_multiple_lp_deposits() {
     context.mint(&provider3, provider3_deposit);
 
     // 3. Provider1 deposits tokens
-    let shares1 = context.client.deposit(&provider1, &provider1_deposit);
+    let shares1 = context.client().deposit(&provider1, &provider1_deposit);
     assert_eq!(shares1, provider1_expected_shares);
 
     // 4. Provider2 deposits tokens
-    let shares2 = context.client.deposit(&provider2, &provider2_deposit);
+    let shares2 = context.client().deposit(&provider2, &provider2_deposit);
     assert_eq!(shares2, provider2_expected_shares);
 
     // 5. Provider3 deposits tokens
-    let shares3 = context.client.deposit(&provider3, &provider3_deposit);
+    let shares3 = context.client().deposit(&provider3, &provider3_deposit);
     assert_eq!(shares3, provider3_expected_shares);
 
     // 6. Verify each provider's share balance is correct
-    let provider1_balance = context.client.get_lp_shares(&provider1);
-    let provider2_balance = context.client.get_lp_shares(&provider2);
-    let provider3_balance = context.client.get_lp_shares(&provider3);
+    let provider1_balance = context.client().get_lp_shares(&provider1);
+    let provider2_balance = context.client().get_lp_shares(&provider2);
+    let provider3_balance = context.client().get_lp_shares(&provider3);
 
     assert_eq!(provider1_balance, provider1_expected_shares);
     assert_eq!(provider2_balance, provider2_expected_shares);
     assert_eq!(provider3_balance, provider3_expected_shares);
 
     // 7. Verify total_shares
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_shares, expected_total_shares);
 
     // 8. Verify total_liquidity
@@ -895,11 +893,11 @@ fn test_withdrawal_with_active_loans() {
     context.mint(&provider, deposit_amount);
 
     // 2. Provider deposits tokens
-    let shares = context.client.deposit(&provider, &deposit_amount);
+    let shares = context.client().deposit(&provider, &deposit_amount);
     assert_eq!(shares, expected_shares);
 
     // Verify initial state
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(
         initial_stats.available_liquidity,
@@ -913,11 +911,11 @@ fn test_withdrawal_with_active_loans() {
 
     // 4. Fund a loan that locks partial liquidity
     context
-        .client
+        .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
 
     // Verify loan funding state
-    let loan_stats = context.client.get_pool_stats();
+    let loan_stats = context.client().get_pool_stats();
     assert_eq!(loan_stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(
         loan_stats.available_liquidity,
@@ -932,18 +930,18 @@ fn test_withdrawal_with_active_loans() {
     assert_eq!(max_withdrawable_shares, withdrawal_shares);
 
     // 6. Withdraw up to available amount - this should succeed
-    let withdrawn_amount = context.client.withdraw(&provider, &withdrawal_shares);
+    let withdrawn_amount = context.client().withdraw(&provider, &withdrawal_shares);
     assert_eq!(withdrawn_amount, expected_withdrawn_amount);
 
     // 7. Verify locked_liquidity remains unchanged
-    let after_withdrawal_stats = context.client.get_pool_stats();
+    let after_withdrawal_stats = context.client().get_pool_stats();
     assert_eq!(
         after_withdrawal_stats.locked_liquidity,
         expected_final_locked
     );
 
     // 8. Verify remaining provider shares
-    let remaining_provider_shares = context.client.get_lp_shares(&provider);
+    let remaining_provider_shares = context.client().get_lp_shares(&provider);
     assert_eq!(remaining_provider_shares, expected_remaining_shares);
 
     // Verify pool state after withdrawal
@@ -972,18 +970,18 @@ fn test_withdrawal_with_active_loans_exceeds_available_shares() {
     // Setup: provider deposits tokens, loan locks liquidity, provider withdraws shares
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    context.client.deposit(&provider, &deposit_amount);
+    context.client().deposit(&provider, &deposit_amount);
 
     let merchant = Address::generate(&context.env);
     context
-        .client
+        .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
-    context.client.withdraw(&provider, &first_withdrawal_shares);
+    context.client().withdraw(&provider, &first_withdrawal_shares);
 
     // Now provider has 400 shares remaining, but available_liquidity is 0
     // Attempt to withdraw 500 shares (more than remaining) - should fail with InsufficientShares
     context
-        .client
+        .client()
         .withdraw(&provider, &second_withdrawal_shares);
 }
 
@@ -1001,18 +999,18 @@ fn test_withdrawal_with_active_loans_no_available_liquidity() {
     // Setup: provider deposits tokens, loan locks liquidity, provider withdraws shares
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    context.client.deposit(&provider, &deposit_amount);
+    context.client().deposit(&provider, &deposit_amount);
 
     let merchant = Address::generate(&context.env);
     context
-        .client
+        .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
-    context.client.withdraw(&provider, &first_withdrawal_shares);
+    context.client().withdraw(&provider, &first_withdrawal_shares);
 
     // Now provider has 400 shares remaining, but available_liquidity is 0
     // Attempt to withdraw any amount when available_liquidity is 0 - should fail
     context
-        .client
+        .client()
         .withdraw(&provider, &second_withdrawal_shares);
 }
 
@@ -1049,30 +1047,30 @@ fn test_share_value_maintained_after_withdrawal() {
     context.mint(&provider2, provider2_deposit);
 
     // 3. Both providers deposit equal amounts
-    let shares1 = context.client.deposit(&provider1, &provider1_deposit);
+    let shares1 = context.client().deposit(&provider1, &provider1_deposit);
     assert_eq!(shares1, provider1_shares);
 
-    let shares2 = context.client.deposit(&provider2, &provider2_deposit);
+    let shares2 = context.client().deposit(&provider2, &provider2_deposit);
     assert_eq!(shares2, provider2_shares);
 
     // 4. Verify initial state
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(stats.total_shares, expected_initial_shares);
     assert_eq!(stats.share_price, expected_initial_share_price);
 
     // 5. First provider withdraws all their shares
     let withdrawn1 = context
-        .client
+        .client()
         .withdraw(&provider1, &provider1_withdrawal_shares);
     assert_eq!(withdrawn1, expected_withdrawn1);
 
     // 6. Verify second provider's shares still represent correct pool value
-    let provider2_shares_balance = context.client.get_lp_shares(&provider2);
+    let provider2_shares_balance = context.client().get_lp_shares(&provider2);
     assert_eq!(provider2_shares_balance, provider2_shares);
 
     // Total pool now has expected liquidity and shares
-    let stats_after_withdrawal = context.client.get_pool_stats();
+    let stats_after_withdrawal = context.client().get_pool_stats();
     assert_eq!(
         stats_after_withdrawal.total_liquidity,
         expected_liquidity_after_withdrawal
@@ -1096,22 +1094,22 @@ fn test_share_value_maintained_after_withdrawal() {
 
     // 8. Second provider withdraws all their shares and receives expected amount
     let withdrawn2 = context
-        .client
+        .client()
         .withdraw(&provider2, &provider2_withdrawal_shares);
     assert_eq!(withdrawn2, expected_withdrawn2);
 
     // 9. Verify pool is empty after both withdrawals
-    let final_stats = context.client.get_pool_stats();
+    let final_stats = context.client().get_pool_stats();
     assert_eq!(final_stats.total_liquidity, expected_final_liquidity);
     assert_eq!(final_stats.total_shares, expected_final_shares);
 
     // Verify both providers have no shares remaining
     assert_eq!(
-        context.client.get_lp_shares(&provider1),
+        context.client().get_lp_shares(&provider1),
         expected_final_provider1_shares
     );
     assert_eq!(
-        context.client.get_lp_shares(&provider2),
+        context.client().get_lp_shares(&provider2),
         expected_final_provider2_shares
     );
 }
@@ -1143,22 +1141,22 @@ fn test_share_value_appreciation_over_time() {
     // 1. Provider deposits tokens
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    let shares = context.client.deposit(&provider, &deposit_amount);
+    let shares = context.client().deposit(&provider, &deposit_amount);
     assert_eq!(shares, expected_shares);
 
     // 2. Record initial share_price
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.share_price, expected_initial_share_price);
 
     // 3. Distribute interest multiple times
     // First interest
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // 4. Verify share_price increases after first distribution
-    let stats_after_first = context.client.get_pool_stats();
+    let stats_after_first = context.client().get_pool_stats();
     assert_eq!(
         stats_after_first.total_liquidity,
         expected_liquidity_after_first
@@ -1171,11 +1169,11 @@ fn test_share_value_appreciation_over_time() {
     // Second interest
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // Verify share_price increases after second distribution
-    let stats_after_second = context.client.get_pool_stats();
+    let stats_after_second = context.client().get_pool_stats();
     assert_eq!(
         stats_after_second.total_liquidity,
         expected_liquidity_after_second
@@ -1188,11 +1186,11 @@ fn test_share_value_appreciation_over_time() {
     // Third interest
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // Verify share_price increases after third distribution
-    let stats_after_third = context.client.get_pool_stats();
+    let stats_after_third = context.client().get_pool_stats();
     assert_eq!(
         stats_after_third.total_liquidity,
         expected_liquidity_after_third
@@ -1203,13 +1201,13 @@ fn test_share_value_appreciation_over_time() {
     );
 
     // 5. Verify final withdrawal amount reflects all accumulated interest
-    let withdrawn = context.client.withdraw(&provider, &withdrawal_shares);
+    let withdrawn = context.client().withdraw(&provider, &withdrawal_shares);
     assert_eq!(withdrawn, expected_final_withdrawal);
 
     // 6. Test that new depositors after interest get fewer shares per token
     let new_provider = Address::generate(&context.env);
     context.mint(&new_provider, new_provider_deposit);
-    let new_shares = context.client.deposit(&new_provider, &new_provider_deposit);
+    let new_shares = context.client().deposit(&new_provider, &new_provider_deposit);
     // With empty pool, first deposit gets 1:1 ratio again
     assert_eq!(new_shares, expected_new_provider_shares);
 }
@@ -1238,7 +1236,7 @@ fn test_pool_empty_state_handling() {
     let expected_final_share_price = 10_000;
 
     // 1. Verify initial empty pool stats
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.total_liquidity, expected_empty_liquidity);
     assert_eq!(initial_stats.total_shares, expected_empty_shares);
     assert_eq!(initial_stats.locked_liquidity, expected_empty_locked);
@@ -1247,36 +1245,36 @@ fn test_pool_empty_state_handling() {
     // 2. Create a provider, mint tokens, deposit them
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    let shares = context.client.deposit(&provider, &deposit_amount);
+    let shares = context.client().deposit(&provider, &deposit_amount);
     assert_eq!(shares, expected_shares);
 
     // Verify pool has liquidity after deposit
-    let after_deposit_stats = context.client.get_pool_stats();
+    let after_deposit_stats = context.client().get_pool_stats();
     assert_eq!(after_deposit_stats.total_liquidity, deposit_amount);
     assert_eq!(after_deposit_stats.total_shares, expected_shares);
 
     // 3. Withdraw all liquidity
-    let returned_amount = context.client.withdraw(&provider, &withdrawal_shares);
+    let returned_amount = context.client().withdraw(&provider, &withdrawal_shares);
     assert_eq!(returned_amount, expected_returned_amount);
 
     // 4. Verify pool returns to empty state
-    let empty_stats = context.client.get_pool_stats();
+    let empty_stats = context.client().get_pool_stats();
     assert_eq!(empty_stats.total_liquidity, expected_empty_liquidity);
     assert_eq!(empty_stats.total_shares, expected_empty_shares);
     assert_eq!(empty_stats.locked_liquidity, expected_empty_locked);
     assert_eq!(empty_stats.share_price, expected_empty_share_price);
 
     // 5. Test calculate_withdrawal with empty pool returns 0
-    let withdrawal_calculation = context.client.calculate_withdrawal(&calculation_shares);
+    let withdrawal_calculation = context.client().calculate_withdrawal(&calculation_shares);
     assert_eq!(withdrawal_calculation, expected_calculation_result);
 
     // 6. Verify next deposit after empty state works correctly (1:1 ratio)
     context.mint(&provider, second_deposit_amount);
-    let new_shares = context.client.deposit(&provider, &second_deposit_amount);
+    let new_shares = context.client().deposit(&provider, &second_deposit_amount);
     assert_eq!(new_shares, expected_second_shares);
 
     // Verify final state shows correct 1:1 ratio
-    let final_stats = context.client.get_pool_stats();
+    let final_stats = context.client().get_pool_stats();
     assert_eq!(final_stats.total_liquidity, expected_final_liquidity);
     assert_eq!(final_stats.total_shares, expected_final_shares);
     assert_eq!(final_stats.share_price, expected_final_share_price);
@@ -1304,38 +1302,38 @@ fn test_small_deposit_rounding() {
     // 1. Make a large initial deposit
     let provider1 = Address::generate(&context.env);
     context.mint(&provider1, provider1_deposit);
-    let shares1 = context.client.deposit(&provider1, &provider1_deposit);
+    let shares1 = context.client().deposit(&provider1, &provider1_deposit);
     assert_eq!(shares1, provider1_expected_shares);
 
     // 2. Distribute interest to increase share_price
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // Verify share_price increased
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, expected_liquidity_after_interest);
     assert_eq!(stats.share_price, expected_share_price);
 
     // 3. Attempt very small deposits
     let provider2 = Address::generate(&context.env);
     context.mint(&provider2, provider2_deposit);
-    let shares2 = context.client.deposit(&provider2, &provider2_deposit);
+    let shares2 = context.client().deposit(&provider2, &provider2_deposit);
 
     // 4. Verify shares are calculated correctly (rounded down)
     assert_eq!(shares2, provider2_expected_shares);
 
     // 5. Verify no share inflation attack is possible
     let withdrawn2 = context
-        .client
+        .client()
         .withdraw(&provider2, &provider2_withdrawal_shares);
     assert!(withdrawn2 <= provider2_deposit);
 
     // 6. Test edge case where deposit is very small but still gets shares
     let provider3 = Address::generate(&context.env);
     context.mint(&provider3, provider3_deposit);
-    let shares3 = context.client.deposit(&provider3, &provider3_deposit);
+    let shares3 = context.client().deposit(&provider3, &provider3_deposit);
     assert_eq!(shares3, provider3_expected_shares);
 }
 
@@ -1373,63 +1371,63 @@ fn test_concurrent_deposits_and_withdrawals() {
     // 1. Multiple providers deposit in sequence
     let provider1 = Address::generate(&context.env);
     context.mint(&provider1, provider1_deposit);
-    let shares1 = context.client.deposit(&provider1, &provider1_deposit);
+    let shares1 = context.client().deposit(&provider1, &provider1_deposit);
     assert_eq!(shares1, provider1_expected_shares);
 
     let provider2 = Address::generate(&context.env);
     context.mint(&provider2, provider2_deposit);
-    let shares2 = context.client.deposit(&provider2, &provider2_deposit);
+    let shares2 = context.client().deposit(&provider2, &provider2_deposit);
     assert_eq!(shares2, provider2_expected_shares);
 
     let provider3 = Address::generate(&context.env);
     context.mint(&provider3, provider3_deposit);
-    let shares3 = context.client.deposit(&provider3, &provider3_deposit);
+    let shares3 = context.client().deposit(&provider3, &provider3_deposit);
     assert_eq!(shares3, provider3_expected_shares);
 
     // Verify initial state
-    let stats1 = context.client.get_pool_stats();
+    let stats1 = context.client().get_pool_stats();
     assert_eq!(stats1.total_liquidity, expected_initial_liquidity);
     assert_eq!(stats1.total_shares, expected_initial_shares);
 
     // 2. Some providers withdraw while others deposit
     let withdrawn1 = context
-        .client
+        .client()
         .withdraw(&provider1, &provider1_withdrawal_shares);
     assert_eq!(withdrawn1, expected_withdrawn1);
 
-    let stats2 = context.client.get_pool_stats();
+    let stats2 = context.client().get_pool_stats();
     assert_eq!(stats2.total_liquidity, expected_liquidity_after_withdrawal);
     assert_eq!(stats2.total_shares, expected_shares_after_withdrawal);
 
     // 3. Distribute interest between operations
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // 4. Verify pool stats remain consistent throughout
-    let stats3 = context.client.get_pool_stats();
+    let stats3 = context.client().get_pool_stats();
     assert_eq!(stats3.total_liquidity, expected_liquidity_after_interest);
     assert_eq!(stats3.total_shares, expected_shares_after_withdrawal);
 
     // New provider deposits after interest
     let provider4 = Address::generate(&context.env);
     context.mint(&provider4, provider4_deposit);
-    let shares4 = context.client.deposit(&provider4, &provider4_deposit);
+    let shares4 = context.client().deposit(&provider4, &provider4_deposit);
     assert_eq!(shares4, provider4_expected_shares);
 
-    let stats4 = context.client.get_pool_stats();
+    let stats4 = context.client().get_pool_stats();
     assert_eq!(stats4.total_liquidity, expected_liquidity_after_provider4);
     assert_eq!(stats4.total_shares, expected_shares_after_provider4);
 
     // 5. Verify all providers can withdraw expected amounts
     let withdrawn2 = context
-        .client
+        .client()
         .withdraw(&provider2, &provider2_withdrawal_shares);
     assert_eq!(withdrawn2, expected_withdrawn2);
 
     // 6. Verify total_liquidity and total_shares always match proportionally
-    let final_stats = context.client.get_pool_stats();
+    let final_stats = context.client().get_pool_stats();
     assert_eq!(final_stats.total_shares, expected_final_shares);
     assert_eq!(final_stats.total_liquidity, expected_final_liquidity);
 }
@@ -1456,11 +1454,11 @@ fn test_loan_funding_reduces_available_liquidity() {
     context.mint(&provider, deposit_amount);
 
     // 2. Provider deposits tokens
-    let shares = context.client.deposit(&provider, &deposit_amount);
+    let shares = context.client().deposit(&provider, &deposit_amount);
     assert_eq!(shares, expected_shares);
 
     // 3. Record initial pool stats
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(
         initial_stats.available_liquidity,
@@ -1474,11 +1472,11 @@ fn test_loan_funding_reduces_available_liquidity() {
 
     // 5. Fund a loan
     context
-        .client
+        .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
 
     // 6. Verify locked_liquidity increased
-    let updated_stats = context.client.get_pool_stats();
+    let updated_stats = context.client().get_pool_stats();
     assert_eq!(updated_stats.locked_liquidity, expected_locked_after_loan);
 
     // 7. Verify available_liquidity decreased
@@ -1521,19 +1519,19 @@ fn test_repayment_increases_pool_value() {
     // 1. Provider deposits tokens
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    context.client.deposit(&provider, &deposit_amount);
+    context.client().deposit(&provider, &deposit_amount);
 
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(initial_stats.share_price, expected_initial_share_price);
 
     // 2. Fund a loan
     let merchant = Address::generate(&context.env);
     context
-        .client
+        .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
 
-    let after_loan_stats = context.client.get_pool_stats();
+    let after_loan_stats = context.client().get_pool_stats();
     assert_eq!(
         after_loan_stats.locked_liquidity,
         expected_locked_after_loan
@@ -1544,17 +1542,17 @@ fn test_repayment_increases_pool_value() {
     );
 
     // Check initial treasury and merchant fund balances
-    let initial_treasury_balance = context.token.balance(&context.treasury);
-    let initial_merchant_fund_balance = context.token.balance(&context.merchant_fund);
+    let initial_treasury_balance = context.token().balance(&context.treasury);
+    let initial_merchant_fund_balance = context.token().balance(&context.merchant_fund);
 
     // 3. Simulate repayment with principal + interest
     context.mint(&context.creditline, total_repayment);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // 4. Verify locked_liquidity decreased by principal amount
-    let after_repayment_stats = context.client.get_pool_stats();
+    let after_repayment_stats = context.client().get_pool_stats();
     assert_eq!(
         after_repayment_stats.locked_liquidity,
         expected_locked_after_repayment
@@ -1573,10 +1571,10 @@ fn test_repayment_increases_pool_value() {
     );
 
     // 7. Verify treasury and merchant_fund received their fee portions
-    let treasury_balance = context.token.balance(&context.treasury);
+    let treasury_balance = context.token().balance(&context.treasury);
     assert_eq!(treasury_balance, initial_treasury_balance + treasury_fee);
 
-    let merchant_fund_balance = context.token.balance(&context.merchant_fund);
+    let merchant_fund_balance = context.token().balance(&context.merchant_fund);
     assert_eq!(
         merchant_fund_balance,
         initial_merchant_fund_balance + merchant_fund_fee
@@ -1603,19 +1601,19 @@ fn test_guarantee_receipt_on_default() {
     // 1. Provider deposits tokens
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    context.client.deposit(&provider, &deposit_amount);
+    context.client().deposit(&provider, &deposit_amount);
 
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(initial_stats.share_price, expected_initial_share_price);
 
     // 2. Fund a loan (locks liquidity)
     let merchant = Address::generate(&context.env);
     context
-        .client
+        .client()
         .fund_loan(&context.creditline, &merchant, &loan_amount);
 
-    let after_loan_stats = context.client.get_pool_stats();
+    let after_loan_stats = context.client().get_pool_stats();
     assert_eq!(
         after_loan_stats.locked_liquidity,
         expected_locked_after_loan
@@ -1632,11 +1630,11 @@ fn test_guarantee_receipt_on_default() {
     // 3. Simulate default with partial guarantee receipt
     context.mint(&context.creditline, guarantee_amount);
     context
-        .client
+        .client()
         .receive_guarantee(&context.creditline, &guarantee_amount);
 
     // 4. Verify locked_liquidity reduced by guarantee amount
-    let after_guarantee_stats = context.client.get_pool_stats();
+    let after_guarantee_stats = context.client().get_pool_stats();
     assert_eq!(
         after_guarantee_stats.locked_liquidity,
         expected_locked_after_guarantee
@@ -1687,52 +1685,52 @@ fn test_withdrawal_calculation_precision() {
     // 1. Setup pool with various states
     let provider = Address::generate(&context.env);
     context.mint(&provider, initial_deposit);
-    context.client.deposit(&provider, &initial_deposit);
+    context.client().deposit(&provider, &initial_deposit);
 
     // 2. Call calculate_withdrawal for different share amounts
-    let calc1 = context.client.calculate_withdrawal(&calc1_shares);
+    let calc1 = context.client().calculate_withdrawal(&calc1_shares);
     assert_eq!(calc1, expected_calc1);
 
-    let calc2 = context.client.calculate_withdrawal(&calc2_shares);
+    let calc2 = context.client().calculate_withdrawal(&calc2_shares);
     assert_eq!(calc2, expected_calc2);
 
     // 3. Perform actual withdrawal
-    let withdrawn1 = context.client.withdraw(&provider, &withdrawal1_shares);
+    let withdrawn1 = context.client().withdraw(&provider, &withdrawal1_shares);
 
     // 4. Verify returned amount matches calculation
     assert_eq!(withdrawn1, calc1);
 
     // Deposit again for more tests
     context.mint(&provider, second_deposit);
-    context.client.deposit(&provider, &second_deposit);
+    context.client().deposit(&provider, &second_deposit);
 
     // 5. Test with edge cases (very small/large amounts, after interest, etc.)
     // Distribute interest
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, expected_liquidity_after_interest);
 
     // Calculate withdrawal after interest
-    let calc3 = context.client.calculate_withdrawal(&calc3_shares);
+    let calc3 = context.client().calculate_withdrawal(&calc3_shares);
     assert_eq!(calc3, expected_calc3);
 
     // Verify actual withdrawal matches
-    let withdrawn2 = context.client.withdraw(&provider, &withdrawal2_shares);
+    let withdrawn2 = context.client().withdraw(&provider, &withdrawal2_shares);
     assert_eq!(withdrawn2, calc3);
 
     // Test very small amount
-    let calc4 = context.client.calculate_withdrawal(&calc4_shares);
-    let withdrawn3 = context.client.withdraw(&provider, &withdrawal3_shares);
+    let calc4 = context.client().calculate_withdrawal(&calc4_shares);
+    let withdrawn3 = context.client().withdraw(&provider, &withdrawal3_shares);
     assert_eq!(withdrawn3, calc4);
 
     // Test very large amount
-    let remaining_shares = context.client.get_lp_shares(&provider);
-    let calc5 = context.client.calculate_withdrawal(&remaining_shares);
-    let withdrawn4 = context.client.withdraw(&provider, &remaining_shares);
+    let remaining_shares = context.client().get_lp_shares(&provider);
+    let calc5 = context.client().calculate_withdrawal(&remaining_shares);
+    let withdrawn4 = context.client().withdraw(&provider, &remaining_shares);
     assert_eq!(withdrawn4, calc5);
 }
 
@@ -1758,15 +1756,15 @@ fn test_share_price_calculation() {
     let expected_final_share_price = 12266;
 
     // 1. Empty pool: share_price should be expected value
-    let empty_stats = context.client.get_pool_stats();
+    let empty_stats = context.client().get_pool_stats();
     assert_eq!(empty_stats.share_price, expected_empty_share_price);
 
     // 2. After first deposit: share_price should remain constant
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    context.client.deposit(&provider, &deposit_amount);
+    context.client().deposit(&provider, &deposit_amount);
 
-    let after_deposit_stats = context.client.get_pool_stats();
+    let after_deposit_stats = context.client().get_pool_stats();
     assert_eq!(
         after_deposit_stats.share_price,
         expected_share_price_after_deposit
@@ -1775,10 +1773,10 @@ fn test_share_price_calculation() {
     // 3. After interest: share_price should increase proportionally
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
-    let after_interest_stats = context.client.get_pool_stats();
+    let after_interest_stats = context.client().get_pool_stats();
     assert_eq!(
         after_interest_stats.total_liquidity,
         expected_liquidity_after_interest
@@ -1789,9 +1787,9 @@ fn test_share_price_calculation() {
     );
 
     // 4. After withdrawal: share_price should remain constant
-    context.client.withdraw(&provider, &withdrawal_shares);
+    context.client().withdraw(&provider, &withdrawal_shares);
 
-    let after_withdrawal_stats = context.client.get_pool_stats();
+    let after_withdrawal_stats = context.client().get_pool_stats();
     assert_eq!(
         after_withdrawal_stats.share_price,
         expected_share_price_after_withdrawal
@@ -1801,14 +1799,14 @@ fn test_share_price_calculation() {
     // Add more interest events
     for _ in 0..loop_iterations {
         context.mint(&context.creditline, loop_interest_amount);
-        context.client.receive_repayment(
+        context.client().receive_repayment(
             &context.creditline,
             &principal_repayment,
             &loop_interest_amount,
         );
     }
 
-    let final_stats = context.client.get_pool_stats();
+    let final_stats = context.client().get_pool_stats();
     assert_eq!(final_stats.total_liquidity, expected_final_liquidity);
     assert_eq!(final_stats.share_price, expected_final_share_price);
 }
@@ -1839,64 +1837,64 @@ fn test_multiple_interest_distributions() {
     // 1. Provider deposits tokens
     let provider = Address::generate(&context.env);
     context.mint(&provider, deposit_amount);
-    context.client.deposit(&provider, &deposit_amount);
+    context.client().deposit(&provider, &deposit_amount);
 
-    let initial_stats = context.client.get_pool_stats();
+    let initial_stats = context.client().get_pool_stats();
     assert_eq!(initial_stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(initial_stats.share_price, expected_initial_share_price);
 
     // 2. Distribute interest event 1
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // 3. Verify share_price increase
-    let stats1 = context.client.get_pool_stats();
+    let stats1 = context.client().get_pool_stats();
     assert_eq!(stats1.total_liquidity, expected_liquidity_after_event1);
     assert_eq!(stats1.share_price, expected_share_price_after_event1);
 
     // 4. Distribute interest event 2
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
     // 5. Verify share_price compounds correctly
-    let stats2 = context.client.get_pool_stats();
+    let stats2 = context.client().get_pool_stats();
     assert_eq!(stats2.total_liquidity, expected_liquidity_after_event2);
     assert_eq!(stats2.share_price, expected_share_price_after_event2);
 
     // 6. Continue for several events
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
-    let stats3 = context.client.get_pool_stats();
+    let stats3 = context.client().get_pool_stats();
     assert_eq!(stats3.total_liquidity, expected_liquidity_after_event3);
     assert_eq!(stats3.share_price, expected_share_price_after_event3);
 
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
-    let stats4 = context.client.get_pool_stats();
+    let stats4 = context.client().get_pool_stats();
     assert_eq!(stats4.total_liquidity, expected_liquidity_after_event4);
     assert_eq!(stats4.share_price, expected_share_price_after_event4);
 
     context.mint(&context.creditline, interest_amount);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &interest_amount);
 
-    let stats5 = context.client.get_pool_stats();
+    let stats5 = context.client().get_pool_stats();
     assert_eq!(stats5.total_liquidity, expected_liquidity_after_event5);
     assert_eq!(stats5.share_price, expected_share_price_after_event5);
 
     // 7. Verify final share value reflects all compounded interest
-    let withdrawn = context.client.withdraw(&provider, &withdrawal_shares);
+    let withdrawn = context.client().withdraw(&provider, &withdrawal_shares);
     assert_eq!(withdrawn, expected_withdrawn);
 }
 
@@ -1917,19 +1915,19 @@ fn test_zero_shares_edge_case() {
     // 1. Create pool with high share_price (large deposit + lots of interest)
     let provider1 = Address::generate(&context.env);
     context.mint(&provider1, provider1_deposit);
-    context.client.deposit(&provider1, &provider1_deposit);
+    context.client().deposit(&provider1, &provider1_deposit);
 
     // Distribute large amount of interest multiple times
     for _ in 0..loop_iterations {
         context.mint(&context.creditline, interest_amount);
-        context.client.receive_repayment(
+        context.client().receive_repayment(
             &context.creditline,
             &principal_repayment,
             &interest_amount,
         );
     }
 
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, expected_total_liquidity);
     assert_eq!(stats.share_price, expected_share_price);
 
@@ -1961,26 +1959,26 @@ fn test_maximum_values_handling() {
     // 1. Test with maximum reasonable token amounts
     let provider = Address::generate(&context.env);
     context.mint(&provider, large_amount);
-    let shares = context.client.deposit(&provider, &large_amount);
+    let shares = context.client().deposit(&provider, &large_amount);
     assert_eq!(shares, expected_shares);
 
     // 2. Test share calculations with large numbers
-    let stats = context.client.get_pool_stats();
+    let stats = context.client().get_pool_stats();
     assert_eq!(stats.total_liquidity, expected_initial_liquidity);
     assert_eq!(stats.total_shares, expected_initial_shares);
     assert_eq!(stats.share_price, expected_initial_share_price);
 
     // 3. Verify no overflow in multiplication/division operations
-    let calc = context.client.calculate_withdrawal(&calc_shares);
+    let calc = context.client().calculate_withdrawal(&calc_shares);
     assert_eq!(calc, expected_calc);
 
     // 4. Test interest distribution with large amounts
     context.mint(&context.creditline, large_interest);
     context
-        .client
+        .client()
         .receive_repayment(&context.creditline, &principal_repayment, &large_interest);
 
-    let stats_after_interest = context.client.get_pool_stats();
+    let stats_after_interest = context.client().get_pool_stats();
     assert_eq!(
         stats_after_interest.total_liquidity,
         expected_liquidity_after_interest
@@ -1993,7 +1991,7 @@ fn test_maximum_values_handling() {
     );
 
     // Test withdrawal with large amounts
-    let withdrawn = context.client.withdraw(&provider, &withdrawal_shares);
+    let withdrawn = context.client().withdraw(&provider, &withdrawal_shares);
     assert_eq!(withdrawn, expected_liquidity_after_interest);
 }
 
@@ -2004,17 +2002,17 @@ fn test_set_treasury() {
     let t = TestEnv::setup();
     let new_treasury = Address::generate(&t.env);
 
-    t.client.set_treasury(&t.admin, &new_treasury);
+    t.client().set_treasury(&t.admin, &new_treasury);
 
     // Verify by distributing interest and checking new treasury receives fees
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
-    let new_treasury_balance = t.token.balance(&new_treasury);
+    let new_treasury_balance = t.token().balance(&new_treasury);
     assert_eq!(new_treasury_balance, 10); // 10% of 100
 }
 
@@ -2025,7 +2023,7 @@ fn test_set_treasury_by_non_admin_fails() {
     let intruder = Address::generate(&t.env);
     let new_treasury = Address::generate(&t.env);
 
-    t.client.set_treasury(&intruder, &new_treasury);
+    t.client().set_treasury(&intruder, &new_treasury);
 }
 
 #[test]
@@ -2033,17 +2031,17 @@ fn test_set_merchant_fund() {
     let t = TestEnv::setup();
     let new_merchant_fund = Address::generate(&t.env);
 
-    t.client.set_merchant_fund(&t.admin, &new_merchant_fund);
+    t.client().set_merchant_fund(&t.admin, &new_merchant_fund);
 
     // Verify by distributing interest and checking new merchant fund receives fees
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
-    let new_merchant_fund_balance = t.token.balance(&new_merchant_fund);
+    let new_merchant_fund_balance = t.token().balance(&new_merchant_fund);
     assert_eq!(new_merchant_fund_balance, 5); // 5% of 100
 }
 
@@ -2054,7 +2052,7 @@ fn test_set_merchant_fund_by_non_admin_fails() {
     let intruder = Address::generate(&t.env);
     let new_merchant_fund = Address::generate(&t.env);
 
-    t.client.set_merchant_fund(&intruder, &new_merchant_fund);
+    t.client().set_merchant_fund(&intruder, &new_merchant_fund);
 }
 
 // ─── receive_repayment Edge Cases ────────────────────────────────────────────
@@ -2065,19 +2063,19 @@ fn test_receive_repayment_with_zero_principal() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Fund a loan
-    t.client.fund_loan(&t.creditline, &merchant, &500);
+    t.client().fund_loan(&t.creditline, &merchant, &500);
 
-    let stats_before = t.client.get_pool_stats();
+    let stats_before = t.client().get_pool_stats();
     assert_eq!(stats_before.locked_liquidity, 500);
 
     // Repay with only interest, no principal
     t.mint(&t.creditline, 50);
-    t.client.receive_repayment(&t.creditline, &0, &50);
+    t.client().receive_repayment(&t.creditline, &0, &50);
 
-    let stats_after = t.client.get_pool_stats();
+    let stats_after = t.client().get_pool_stats();
     // Locked should remain unchanged
     assert_eq!(stats_after.locked_liquidity, 500);
     // Total liquidity should increase by LP portion (85% of 50 = 42)
@@ -2090,16 +2088,16 @@ fn test_receive_repayment_with_zero_interest() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Fund a loan
-    t.client.fund_loan(&t.creditline, &merchant, &500);
+    t.client().fund_loan(&t.creditline, &merchant, &500);
 
     // Repay with only principal, no interest
     t.mint(&t.creditline, 500);
-    t.client.receive_repayment(&t.creditline, &500, &0);
+    t.client().receive_repayment(&t.creditline, &500, &0);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     // Locked should be reduced to zero
     assert_eq!(stats.locked_liquidity, 0);
     // Total liquidity should remain unchanged (no interest added)
@@ -2110,14 +2108,14 @@ fn test_receive_repayment_with_zero_interest() {
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_receive_repayment_negative_principal_fails() {
     let t = TestEnv::setup();
-    t.client.receive_repayment(&t.creditline, &-100, &50);
+    t.client().receive_repayment(&t.creditline, &-100, &50);
 }
 
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_receive_repayment_negative_interest_fails() {
     let t = TestEnv::setup();
-    t.client.receive_repayment(&t.creditline, &100, &-50);
+    t.client().receive_repayment(&t.creditline, &100, &-50);
 }
 
 #[test]
@@ -2125,7 +2123,7 @@ fn test_receive_repayment_negative_interest_fails() {
 fn test_receive_repayment_unauthorized_caller_fails() {
     let t = TestEnv::setup();
     let intruder = Address::generate(&t.env);
-    t.client.receive_repayment(&intruder, &100, &50);
+    t.client().receive_repayment(&intruder, &100, &50);
 }
 
 // ─── receive_guarantee Edge Cases ────────────────────────────────────────────
@@ -2134,14 +2132,14 @@ fn test_receive_repayment_unauthorized_caller_fails() {
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_receive_guarantee_with_zero_amount_fails() {
     let t = TestEnv::setup();
-    t.client.receive_guarantee(&t.creditline, &0);
+    t.client().receive_guarantee(&t.creditline, &0);
 }
 
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_receive_guarantee_negative_amount_fails() {
     let t = TestEnv::setup();
-    t.client.receive_guarantee(&t.creditline, &-100);
+    t.client().receive_guarantee(&t.creditline, &-100);
 }
 
 #[test]
@@ -2149,7 +2147,7 @@ fn test_receive_guarantee_negative_amount_fails() {
 fn test_receive_guarantee_unauthorized_caller_fails() {
     let t = TestEnv::setup();
     let intruder = Address::generate(&t.env);
-    t.client.receive_guarantee(&intruder, &100);
+    t.client().receive_guarantee(&intruder, &100);
 }
 
 #[test]
@@ -2158,20 +2156,20 @@ fn test_receive_guarantee_exceeds_locked_liquidity() {
     let provider = Address::generate(&t.env);
     let merchant = Address::generate(&t.env);
     t.mint(&provider, 1_000);
-    t.client.deposit(&provider, &1_000);
+    t.client().deposit(&provider, &1_000);
 
     // Fund a loan for 500
-    t.client.fund_loan(&t.creditline, &merchant, &500);
+    t.client().fund_loan(&t.creditline, &merchant, &500);
 
     // Receive guarantee of 600 (more than locked 500)
-    // The contract should cap recovery at locked amount (500)
+    // Contract caps recovery at locked (500) and transfers only 500
     t.mint(&t.creditline, 600);
-    t.client.receive_guarantee(&t.creditline, &600);
+    t.client().receive_guarantee(&t.creditline, &600);
 
-    let stats = t.client.get_pool_stats();
-    // Locked should be reduced to 0 (capped at 500)
+    let stats = t.client().get_pool_stats();
+    // Locked reduced to 0 (capped at 500)
     assert_eq!(stats.locked_liquidity, 0);
-    // Total liquidity should increase by only 500 (not 600)
+    // Total liquidity increases by recovered (500), not full amount (600)
     assert_eq!(stats.total_liquidity, 1_500);
 }
 
@@ -2182,7 +2180,7 @@ fn test_receive_guarantee_exceeds_locked_liquidity() {
 fn test_fund_loan_with_zero_amount_fails() {
     let t = TestEnv::setup();
     let merchant = Address::generate(&t.env);
-    t.client.fund_loan(&t.creditline, &merchant, &0);
+    t.client().fund_loan(&t.creditline, &merchant, &0);
 }
 
 #[test]
@@ -2190,7 +2188,7 @@ fn test_fund_loan_with_zero_amount_fails() {
 fn test_fund_loan_with_negative_amount_fails() {
     let t = TestEnv::setup();
     let merchant = Address::generate(&t.env);
-    t.client.fund_loan(&t.creditline, &merchant, &-500);
+    t.client().fund_loan(&t.creditline, &merchant, &-500);
 }
 
 // ─── distribute_interest Edge Cases ──────────────────────────────────────────
@@ -2202,7 +2200,7 @@ fn test_fund_loan_with_negative_amount_fails() {
 fn test_receive_repayment_with_zero_total_fails() {
     let t = TestEnv::setup();
     // Both principal and interest are zero - should fail
-    t.client.receive_repayment(&t.creditline, &0, &0);
+    t.client().receive_repayment(&t.creditline, &0, &0);
 }
 
 // ─── Integration Scenarios ───────────────────────────────────────────────────
@@ -2212,18 +2210,18 @@ fn test_multiple_loans_concurrent_funding() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 10_000);
-    t.client.deposit(&provider, &10_000);
+    t.client().deposit(&provider, &10_000);
 
     let merchant1 = Address::generate(&t.env);
     let merchant2 = Address::generate(&t.env);
     let merchant3 = Address::generate(&t.env);
 
     // Fund multiple loans
-    t.client.fund_loan(&t.creditline, &merchant1, &2_000);
-    t.client.fund_loan(&t.creditline, &merchant2, &3_000);
-    t.client.fund_loan(&t.creditline, &merchant3, &1_500);
+    t.client().fund_loan(&t.creditline, &merchant1, &2_000);
+    t.client().fund_loan(&t.creditline, &merchant2, &3_000);
+    t.client().fund_loan(&t.creditline, &merchant3, &1_500);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     assert_eq!(stats.locked_liquidity, 6_500);
     assert_eq!(stats.available_liquidity, 3_500);
     assert_eq!(stats.total_liquidity, 10_000);
@@ -2234,28 +2232,28 @@ fn test_partial_guarantee_recovery_multiple_defaults() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 10_000);
-    t.client.deposit(&provider, &10_000);
+    t.client().deposit(&provider, &10_000);
 
     let merchant1 = Address::generate(&t.env);
     let merchant2 = Address::generate(&t.env);
 
     // Fund two loans
-    t.client.fund_loan(&t.creditline, &merchant1, &3_000);
-    t.client.fund_loan(&t.creditline, &merchant2, &2_000);
+    t.client().fund_loan(&t.creditline, &merchant1, &3_000);
+    t.client().fund_loan(&t.creditline, &merchant2, &2_000);
 
     // First default with partial guarantee
     t.mint(&t.creditline, 1_000);
-    t.client.receive_guarantee(&t.creditline, &1_000);
+    t.client().receive_guarantee(&t.creditline, &1_000);
 
-    let stats_after_first = t.client.get_pool_stats();
+    let stats_after_first = t.client().get_pool_stats();
     assert_eq!(stats_after_first.locked_liquidity, 4_000); // 5000 - 1000
     assert_eq!(stats_after_first.total_liquidity, 11_000); // 10000 + 1000
 
     // Second default with partial guarantee
     t.mint(&t.creditline, 800);
-    t.client.receive_guarantee(&t.creditline, &800);
+    t.client().receive_guarantee(&t.creditline, &800);
 
-    let stats_after_second = t.client.get_pool_stats();
+    let stats_after_second = t.client().get_pool_stats();
     assert_eq!(stats_after_second.locked_liquidity, 3_200); // 4000 - 800
     assert_eq!(stats_after_second.total_liquidity, 11_800); // 11000 + 800
 }
@@ -2270,34 +2268,34 @@ fn test_complex_lifecycle_deposits_loans_repayments_withdrawals() {
     t.mint(&provider1, 5_000);
     t.mint(&provider2, 3_000);
 
-    t.client.deposit(&provider1, &5_000);
-    t.client.deposit(&provider2, &3_000);
+    t.client().deposit(&provider1, &5_000);
+    t.client().deposit(&provider2, &3_000);
 
     // Fund loans
     let merchant = Address::generate(&t.env);
-    t.client.fund_loan(&t.creditline, &merchant, &4_000);
+    t.client().fund_loan(&t.creditline, &merchant, &4_000);
 
     // Partial repayment with interest
     t.mint(&t.creditline, 2_500);
-    t.client.receive_repayment(&t.creditline, &2_000, &500);
+    t.client().receive_repayment(&t.creditline, &2_000, &500);
 
-    let stats_mid = t.client.get_pool_stats();
+    let stats_mid = t.client().get_pool_stats();
     assert_eq!(stats_mid.locked_liquidity, 2_000);
 
     // Provider1 withdraws some shares
-    let shares_to_withdraw = t.client.get_lp_shares(&provider1) / 2;
-    t.client.withdraw(&provider1, &shares_to_withdraw);
+    let shares_to_withdraw = t.client().get_lp_shares(&provider1) / 2;
+    t.client().withdraw(&provider1, &shares_to_withdraw);
 
     // Complete repayment
     t.mint(&t.creditline, 2_200);
-    t.client.receive_repayment(&t.creditline, &2_000, &200);
+    t.client().receive_repayment(&t.creditline, &2_000, &200);
 
-    let stats_final = t.client.get_pool_stats();
+    let stats_final = t.client().get_pool_stats();
     assert_eq!(stats_final.locked_liquidity, 0);
 
     // Both providers can withdraw remaining shares
-    let remaining1 = t.client.get_lp_shares(&provider1);
-    let remaining2 = t.client.get_lp_shares(&provider2);
+    let remaining1 = t.client().get_lp_shares(&provider1);
+    let remaining2 = t.client().get_lp_shares(&provider2);
 
     assert!(remaining1 > 0);
     assert!(remaining2 > 0);
@@ -2310,12 +2308,12 @@ fn test_interest_distribution_with_empty_pool() {
     // Try to distribute interest when pool is empty
     // This should not panic but also not do anything meaningful
     t.mint(&t.creditline, 100);
-    t.client.receive_repayment(&t.creditline, &0, &100);
+    t.client().receive_repayment(&t.creditline, &0, &100);
 
-    let stats = t.client.get_pool_stats();
+    let stats = t.client().get_pool_stats();
     // With no shares, interest still gets distributed to treasury/merchant fund
-    assert_eq!(t.token.balance(&t.treasury), 10);
-    assert_eq!(t.token.balance(&t.merchant_fund), 5);
+    assert_eq!(t.token().balance(&t.treasury), 10);
+    assert_eq!(t.token().balance(&t.merchant_fund), 5);
     // LP portion (85) stays in pool
     assert_eq!(stats.total_liquidity, 85);
 }
@@ -2326,16 +2324,16 @@ fn test_withdrawal_after_multiple_interest_distributions() {
     let provider = Address::generate(&t.env);
     t.mint(&provider, 1_000);
 
-    let shares = t.client.deposit(&provider, &1_000);
+    let shares = t.client().deposit(&provider, &1_000);
 
     // Multiple interest distributions
     for _ in 0..5 {
         t.mint(&t.creditline, 100);
-        t.client.receive_repayment(&t.creditline, &0, &100);
+        t.client().receive_repayment(&t.creditline, &0, &100);
     }
 
     // Withdraw all shares
-    let withdrawn = t.client.withdraw(&provider, &shares);
+    let withdrawn = t.client().withdraw(&provider, &shares);
 
     // Should receive original + accumulated interest
     // 5 * 85 (LP portion) = 425
@@ -2347,25 +2345,101 @@ fn test_loan_funding_and_guarantee_recovery_cycle() {
     let t = TestEnv::setup();
     let provider = Address::generate(&t.env);
     t.mint(&provider, 5_000);
-    t.client.deposit(&provider, &5_000);
+    t.client().deposit(&provider, &5_000);
 
     let merchant = Address::generate(&t.env);
 
     // Fund loan
-    t.client.fund_loan(&t.creditline, &merchant, &2_000);
+    t.client().fund_loan(&t.creditline, &merchant, &2_000);
 
     // Partial guarantee recovery
     t.mint(&t.creditline, 500);
-    t.client.receive_guarantee(&t.creditline, &500);
+    t.client().receive_guarantee(&t.creditline, &500);
 
-    let stats_after_guarantee = t.client.get_pool_stats();
+    let stats_after_guarantee = t.client().get_pool_stats();
     assert_eq!(stats_after_guarantee.locked_liquidity, 1_500);
     assert_eq!(stats_after_guarantee.total_liquidity, 5_500);
 
     // Fund another loan
-    t.client.fund_loan(&t.creditline, &merchant, &1_000);
+    t.client().fund_loan(&t.creditline, &merchant, &1_000);
 
-    let stats_final = t.client.get_pool_stats();
+    let stats_final = t.client().get_pool_stats();
     assert_eq!(stats_final.locked_liquidity, 2_500);
     assert_eq!(stats_final.available_liquidity, 3_000);
+}
+
+// ─── pause / emergency stop ───────────────────────────────────────────────────
+
+#[test]
+fn test_not_paused_by_default() {
+    let t = TestEnv::setup();
+    assert!(!t.client().is_paused());
+}
+
+#[test]
+fn test_admin_can_pause_and_unpause() {
+    let t = TestEnv::setup();
+    t.client().pause(&t.admin);
+    assert!(t.client().is_paused());
+    t.client().unpause(&t.admin);
+    assert!(!t.client().is_paused());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_non_admin_cannot_pause() {
+    let t = TestEnv::setup();
+    let intruder = Address::generate(&t.env);
+    t.client().pause(&intruder);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_deposit_blocked_when_paused() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 1_000);
+    t.client().pause(&t.admin);
+    t.client().deposit(&provider, &1_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_withdraw_blocked_when_paused() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 1_000);
+    t.client().deposit(&provider, &1_000);
+    t.client().pause(&t.admin);
+    t.client().withdraw(&provider, &1_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_fund_loan_blocked_when_paused() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    let merchant = Address::generate(&t.env);
+    t.mint(&provider, 1_000);
+    t.client().deposit(&provider, &1_000);
+    t.client().pause(&t.admin);
+    t.client().fund_loan(&t.creditline, &merchant, &500);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_receive_repayment_blocked_when_paused() {
+    let t = TestEnv::setup();
+    t.client().pause(&t.admin);
+    t.mint(&t.creditline, 100);
+    t.client().receive_repayment(&t.creditline, &100, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_receive_guarantee_blocked_when_paused() {
+    let t = TestEnv::setup();
+    t.client().pause(&t.admin);
+    t.mint(&t.creditline, 100);
+    t.client().receive_guarantee(&t.creditline, &100);
 }


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses all critical, high, medium, and low severity findings from the recent security audit of the `liquidity-pool-contract`. It hardens access control, corrects accounting logic, implements an emergency pause mechanism, and ensures storage TTLs are properly managed to prevent contract archival.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- **[C-1]** Secured `distribute_interest` with strict `require_auth` and caller identity verification (Admin/CreditLine only).
- **[H-1 & H-2]** Created `access.rs` to standardize administrative gating and updated `set_admin` to comply with Soroban auth patterns.
- **[H-3 & H-4]** Fixed the `receive_guarantee` accounting mismatch and enforced `MIN_AMOUNT` on deposits.
- **[M-1 & M-2]** Added public read accessors for token, treasury, merchant fund, and creditline addresses.
- **[M-3 & M-4]** Implemented TTL extensions (`bump_instance` and `bump_lp_shares`) across all state-mutating and relevant read functions to prevent state expiration.
- **[M-5]** Added a comprehensive emergency pause mechanism (`pause`, `unpause`, `is_paused`) blocking all state-mutating operations when active.
- **[L-1 & L-3]** Cleaned up unused constants and removed `unsafe { core::mem::transmute }` from test helpers, replacing it with safe, lifetime-bound client generation.

## Testing
- [x] Tests pass locally (85/85 tests passing)
- [x] New tests added (8 new tests added specifically covering the pause/unpause mechanism and authorization failures)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated (constants and new error codes)
- [x] No new warnings generated


- Close #70 

<img width="1269" height="630" alt="Screenshot From 2026-06-17 10-13-16" src="https://github.com/user-attachments/assets/c86fc744-d305-46cb-8468-d93e69f6d000" />
<img width="1269" height="630" alt="Screenshot From 2026-06-17 10-11-49" src="https://github.com/user-attachments/assets/61702d8c-7e21-4698-aabf-f24cf2cf1527" />
