### PR TITLE
feat: evaluate and cleanup adapter-trustless-contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ members = [
 ]
 resolver = "2"
 
-# Future contracts:
-# - contracts/adapter-trustless-contract
-
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -508,16 +508,6 @@ Comprehensive test coverage for all contracts.
 
 ---
 
-## Unplanned Contracts
-
-### adapter-trustless-contract
-
-**Status:** Empty (`.gitkeep` only)
-**Purpose:** Unknown — not in original roadmap
-**Action Required:** Clarify scope or remove
-
----
-
 ## Notes
 
 - All completed phases (1-2) have excellent test coverage


### PR DESCRIPTION
## Description
Removes the empty `adapter-trustless-contract` directory which was not part of the original roadmap and had no current implementation. Cleans up the associated comment in `Cargo.toml` and the "Unplanned Contracts" section in `docs/ROADMAP.md`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made
- Deleted `contracts/adapter-trustless-contract/` directory (contained only `.gitkeep`, no implementation)
- Removed commented-out future contract reference from `Cargo.toml`
- Removed the "Unplanned Contracts" section from `docs/ROADMAP.md`

## Testing
- [x] Tests pass locally
- [ ] New tests added (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated


Closes #74 