### PR TITLE
feat(sc-13): implement merchant registration with MerchantMetadata struct

### DIFF
--- a/contracts/merchant-registry-contract/src/errors.rs
+++ b/contracts/merchant-registry-contract/src/errors.rs
@@ -10,4 +10,6 @@ pub enum Error {
     MerchantNotFound = 4,
     InvalidName = 5,
     Unauthorized = 6,
+    InvalidMetadata = 7,
 }
+

--- a/contracts/merchant-registry-contract/src/events.rs
+++ b/contracts/merchant-registry-contract/src/events.rs
@@ -1,11 +1,13 @@
-use soroban_sdk::{Address, Env, String, Symbol};
+use crate::types::MerchantMetadata;
+use soroban_sdk::{Address, Env, Symbol};
 
-pub fn publish_merchant_registered(env: &Env, merchant: Address, name: String) {
+pub fn publish_merchant_registered(env: &Env, merchant: Address, metadata: MerchantMetadata) {
     let topics = (Symbol::new(env, "MERCHTREG"), merchant);
-    env.events().publish(topics, name);
+    env.events().publish(topics, metadata);
 }
 
 pub fn publish_merchant_status(env: &Env, merchant: Address, active: bool) {
     let topics = (Symbol::new(env, "MERCHTSTATUS"), merchant);
     env.events().publish(topics, active);
 }
+

--- a/contracts/merchant-registry-contract/src/lib.rs
+++ b/contracts/merchant-registry-contract/src/lib.rs
@@ -10,11 +10,12 @@ mod types;
 mod tests;
 
 use errors::Error;
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
-use types::MerchantInfo;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+use types::{MerchantInfo, MerchantMetadata as MerchantMeta};
 
-// Export Error type for external use
+// Export types for external use
 pub use errors::Error as MerchantRegistryError;
+pub use types::MerchantMetadata;
 
 #[contract]
 pub struct MerchantRegistryContract;
@@ -30,30 +31,52 @@ impl MerchantRegistryContract {
         Ok(())
     }
 
-    /// Registers a new merchant
+    /// Registers a new merchant with full metadata.
+    ///
+    /// # Arguments
+    /// * `admin`    — Must match the stored admin address (auth required)
+    /// * `merchant` — The on-chain address to be registered
+    /// * `metadata` — `MerchantMetadata { name, business_type, contact_info }`
+    ///
+    /// # Errors
+    /// * `NotInitialized`          — Contract has not been initialized
+    /// * `Unauthorized`            — Caller is not the admin
+    /// * `MerchantAlreadyRegistered` — Address already registered
+    /// * `InvalidName`             — name is empty or longer than 64 chars
+    /// * `InvalidMetadata`         — business_type or contact_info too long
     pub fn register_merchant(
         env: Env,
         admin: Address,
         merchant: Address,
-        name: String,
+        metadata: MerchantMeta,
     ) -> Result<(), Error> {
         if !storage::has_admin(&env) {
             return Err(Error::NotInitialized);
         }
 
-        // ⬇️ Updated to handle the Result
         access::require_admin(&env, &admin)?;
 
         if storage::has_merchant(&env, &merchant) {
             return Err(Error::MerchantAlreadyRegistered);
         }
 
-        if name.len() == 0 || name.len() > 64 {
+        // Validate name: 1–64 chars
+        if metadata.name.len() == 0 || metadata.name.len() > 64 {
             return Err(Error::InvalidName);
         }
 
+        // Validate business_type: max 64 chars
+        if metadata.business_type.len() > 64 {
+            return Err(Error::InvalidMetadata);
+        }
+
+        // Validate contact_info: max 128 chars
+        if metadata.contact_info.len() > 128 {
+            return Err(Error::InvalidMetadata);
+        }
+
         let info = MerchantInfo {
-            name: name.clone(),
+            metadata: metadata.clone(),
             registration_date: env.ledger().timestamp(),
             active: true,
             total_sales: 0,
@@ -61,7 +84,7 @@ impl MerchantRegistryContract {
 
         storage::set_merchant(&env, &merchant, &info);
         storage::increment_merchant_count(&env);
-        events::publish_merchant_registered(&env, merchant, name);
+        events::publish_merchant_registered(&env, merchant, metadata);
 
         Ok(())
     }
@@ -123,6 +146,7 @@ impl MerchantRegistryContract {
         Ok(())
     }
 
+    /// Returns whether the merchant is currently active
     pub fn is_active(env: Env, merchant: Address) -> bool {
         if let Some(info) = storage::get_merchant(&env, &merchant) {
             info.active
@@ -131,11 +155,14 @@ impl MerchantRegistryContract {
         }
     }
 
+    /// Returns the full MerchantInfo record for a registered merchant
     pub fn get_merchant_info(env: Env, merchant: Address) -> Result<MerchantInfo, Error> {
         storage::get_merchant(&env, &merchant).ok_or(Error::MerchantNotFound)
     }
 
+    /// Returns the total number of registered merchants
     pub fn get_merchant_count(env: Env) -> u64 {
         storage::get_merchant_count(&env)
     }
 }
+

--- a/contracts/merchant-registry-contract/src/tests.rs
+++ b/contracts/merchant-registry-contract/src/tests.rs
@@ -6,15 +6,22 @@ use soroban_sdk::{
     Address, Env, String,
 };
 
+/// Helper to build a valid MerchantMetadata for tests
+fn make_metadata(env: &Env, name: &str, btype: &str, contact: &str) -> MerchantMetadata {
+    MerchantMetadata {
+        name: String::from_str(env, name),
+        business_type: String::from_str(env, btype),
+        contact_info: String::from_str(env, contact),
+    }
+}
+
 /// Helper function to set up the environment, contract, and test addresses.
 fn setup<'a>(env: &'a Env) -> (MerchantRegistryContractClient<'a>, Address, Address) {
-    // Using the updated register syntax
     let contract_id = env.register(MerchantRegistryContract, ());
     let client = MerchantRegistryContractClient::new(env, &contract_id);
     let admin = Address::generate(env);
     let merchant = Address::generate(env);
 
-    // Initialize the contract with the admin
     client.initialize(&admin);
 
     (client, admin, merchant)
@@ -23,7 +30,6 @@ fn setup<'a>(env: &'a Env) -> (MerchantRegistryContractClient<'a>, Address, Addr
 #[test]
 fn test_initialization() {
     let env = Env::default();
-    // Using the updated register syntax
     let contract_id = env.register(MerchantRegistryContract, ());
     let client = MerchantRegistryContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -42,21 +48,47 @@ fn test_registration_flow() {
     let (client, admin, merchant) = setup(&env);
 
     env.mock_all_auths();
-    // Advance ledger time to test registration_date
-    env.ledger().with_mut(|l| l.timestamp = 1000000);
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
 
-    let name = String::from_str(&env, "Galaxy Tech Supplies");
-    client.register_merchant(&admin, &merchant, &name);
+    let metadata = make_metadata(&env, "Galaxy Tech Supplies", "retail", "galaxy@tech.com");
+    client.register_merchant(&admin, &merchant, &metadata);
 
     assert!(client.is_active(&merchant));
 
-    // get_merchant_info automatically unwraps on success in the test client
     let info = client.get_merchant_info(&merchant);
-    assert_eq!(info.name, name);
-    assert_eq!(info.registration_date, 1000000);
+    assert_eq!(info.metadata.name, metadata.name);
+    assert_eq!(info.metadata.business_type, metadata.business_type);
+    assert_eq!(info.metadata.contact_info, metadata.contact_info);
+    assert_eq!(info.registration_date, 1_000_000);
     assert_eq!(info.active, true);
     assert_eq!(info.total_sales, 0);
     assert_eq!(client.get_merchant_count(), 1);
+}
+
+#[test]
+fn test_metadata_stored_correctly() {
+    let env = Env::default();
+    let (client, admin, merchant) = setup(&env);
+    env.mock_all_auths();
+
+    let metadata = make_metadata(
+        &env,
+        "Stellar Books",
+        "bookstore",
+        "https://stellar-books.example",
+    );
+    client.register_merchant(&admin, &merchant, &metadata);
+
+    let info = client.get_merchant_info(&merchant);
+    assert_eq!(info.metadata.name, String::from_str(&env, "Stellar Books"));
+    assert_eq!(
+        info.metadata.business_type,
+        String::from_str(&env, "bookstore")
+    );
+    assert_eq!(
+        info.metadata.contact_info,
+        String::from_str(&env, "https://stellar-books.example")
+    );
 }
 
 #[test]
@@ -65,11 +97,11 @@ fn test_duplicate_prevention() {
     let (client, admin, merchant) = setup(&env);
     env.mock_all_auths();
 
-    let name = String::from_str(&env, "Stellar Books");
-    client.register_merchant(&admin, &merchant, &name);
+    let metadata = make_metadata(&env, "Stellar Books", "retail", "info@stellar.com");
+    client.register_merchant(&admin, &merchant, &metadata);
 
     // Registering the exact same address again should fail
-    let res = client.try_register_merchant(&admin, &merchant, &name);
+    let res = client.try_register_merchant(&admin, &merchant, &metadata);
     assert!(res.is_err());
 }
 
@@ -79,12 +111,61 @@ fn test_admin_only_access() {
     let (client, _admin, merchant) = setup(&env);
     env.mock_all_auths();
 
-    // Create a rogue admin address
     let fake_admin = Address::generate(&env);
-    let name = String::from_str(&env, "Rogue Merchant");
+    let metadata = make_metadata(&env, "Rogue Merchant", "unknown", "rogue@rogue.com");
 
-    // Use try_register_merchant to catch the expected Unauthorized error
-    let res = client.try_register_merchant(&fake_admin, &merchant, &name);
+    let res = client.try_register_merchant(&fake_admin, &merchant, &metadata);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_invalid_name_empty() {
+    let env = Env::default();
+    let (client, admin, merchant) = setup(&env);
+    env.mock_all_auths();
+
+    // Empty name should be rejected
+    let metadata = make_metadata(&env, "", "retail", "contact@shop.com");
+    let res = client.try_register_merchant(&admin, &merchant, &metadata);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_invalid_name_too_long() {
+    let env = Env::default();
+    let (client, admin, merchant) = setup(&env);
+    env.mock_all_auths();
+
+    // 65-char name should be rejected
+    let long_name = "A".repeat(65);
+    let metadata = make_metadata(&env, &long_name, "retail", "contact@shop.com");
+    let res = client.try_register_merchant(&admin, &merchant, &metadata);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_invalid_business_type_too_long() {
+    let env = Env::default();
+    let (client, admin, merchant) = setup(&env);
+    env.mock_all_auths();
+
+    // business_type > 64 chars should be rejected
+    let long_type = "B".repeat(65);
+    let metadata = make_metadata(&env, "Valid Name", &long_type, "contact@shop.com");
+    let res = client.try_register_merchant(&admin, &merchant, &metadata);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_invalid_contact_info_too_long() {
+    let env = Env::default();
+    let (client, admin, merchant) = setup(&env);
+    env.mock_all_auths();
+
+    // contact_info > 128 chars should be rejected
+    let long_contact = "C".repeat(129);
+    let metadata = make_metadata(&env, "Valid Name", "retail", &long_contact);
+    let res = client.try_register_merchant(&admin, &merchant, &metadata);
     assert!(res.is_err());
 }
 
@@ -94,8 +175,8 @@ fn test_activation_and_deactivation() {
     let (client, admin, merchant) = setup(&env);
     env.mock_all_auths();
 
-    let name = String::from_str(&env, "Nebula Cafe");
-    client.register_merchant(&admin, &merchant, &name);
+    let metadata = make_metadata(&env, "Nebula Cafe", "food", "nebula@cafe.com");
+    client.register_merchant(&admin, &merchant, &metadata);
 
     assert!(client.is_active(&merchant));
 
@@ -116,10 +197,9 @@ fn test_set_merchant_status() {
     let (client, admin, merchant) = setup(&env);
     env.mock_all_auths();
 
-    let name = String::from_str(&env, "Quasar Goods");
-    client.register_merchant(&admin, &merchant, &name);
+    let metadata = make_metadata(&env, "Quasar Goods", "wholesale", "quasar@goods.com");
+    client.register_merchant(&admin, &merchant, &metadata);
 
-    // Merchant starts active
     assert!(client.is_active(&merchant));
 
     // Deactivate via set_merchant_status
@@ -135,3 +215,26 @@ fn test_set_merchant_status() {
     let res = client.try_set_merchant_status(&fake_admin, &merchant, &false);
     assert!(res.is_err());
 }
+
+#[test]
+fn test_merchant_count_increments() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+    env.mock_all_auths();
+
+    assert_eq!(client.get_merchant_count(), 0);
+
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+    let m3 = Address::generate(&env);
+
+    client.register_merchant(&admin, &m1, &make_metadata(&env, "Merchant One", "retail", "m1@test.com"));
+    assert_eq!(client.get_merchant_count(), 1);
+
+    client.register_merchant(&admin, &m2, &make_metadata(&env, "Merchant Two", "food", "m2@test.com"));
+    assert_eq!(client.get_merchant_count(), 2);
+
+    client.register_merchant(&admin, &m3, &make_metadata(&env, "Merchant Three", "services", "m3@test.com"));
+    assert_eq!(client.get_merchant_count(), 3);
+}
+

--- a/contracts/merchant-registry-contract/src/types.rs
+++ b/contracts/merchant-registry-contract/src/types.rs
@@ -11,11 +11,25 @@ pub enum DataKey {
     MerchantCount,
 }
 
+/// Metadata provided at registration time by the admin.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantMetadata {
+    /// Display name of the merchant (1–64 chars)
+    pub name: String,
+    /// Category or type of business (e.g. "retail", "services")
+    pub business_type: String,
+    /// Contact information (e.g. email or URL, max 128 chars)
+    pub contact_info: String,
+}
+
+/// Full on-chain record for a registered merchant.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MerchantInfo {
-    pub name: String,
+    pub metadata: MerchantMetadata,
     pub registration_date: u64,
     pub active: bool,
     pub total_sales: u64,
 }
+


### PR DESCRIPTION
## Description
Implements SC-13: Merchant Registration for the `merchant-registry-contract`, aligning the contract with the issue specification.

The key change is updating `register_merchant` to accept a `MerchantMetadata` struct instead of a bare `name: String`, enabling richer merchant data to be stored and emitted on-chain.

## Type of Change
- [x] New feature

## Changes Made
- **`types.rs`** — Added `MerchantMetadata { name, business_type, contact_info }` struct; `MerchantInfo` now embeds `metadata: MerchantMetadata` instead of a bare `name` field
- **`lib.rs`** — Updated `register_merchant(admin, merchant, metadata)` signature per issue spec; added validation for all metadata fields; documented error variants
- **`errors.rs`** — Added `InvalidMetadata = 7` error variant for `business_type`/`contact_info` length validation
- **`events.rs`** — `MerchantRegistered` event now emits full `MerchantMetadata` payload instead of just a name string

## Testing
- [x] Tests pass locally
- [x] New tests added (if applicable)

New tests added (12 total):
- `test_registration_flow` — full happy path with metadata fields
- `test_metadata_stored_correctly` — verifies all 3 metadata fields persist correctly
- `test_invalid_name_empty` — rejects empty name
- `test_invalid_name_too_long` — rejects name > 64 chars
- `test_invalid_business_type_too_long` — rejects business_type > 64 chars
- `test_invalid_contact_info_too_long` — rejects contact_info > 128 chars
- `test_merchant_count_increments` — verifies count tracking across multiple registrations

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated

Closes #68