### PR TITLE
feat(SC-17): implement and test interest distribution in Liquidity Pool

### DIFF
--- a/contracts/liquidity-pool-contract/src/tests.rs
+++ b/contracts/liquidity-pool-contract/src/tests.rs
@@ -1,8 +1,9 @@
 use crate::{LiquidityPoolContract, LiquidityPoolContractClient};
 use soroban_sdk::{
-    testutils::Address as _,
+    symbol_short,
+    testutils::{Address as _, Events},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env,
+    Address, Env, IntoVal, Symbol, Val, Vec,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -2610,4 +2611,51 @@ fn test_distribute_interest_proportional_to_multiple_lps() {
     // Each LP (1000 shares of 3000): 1000 * 3255 / 3000 = 1085
     let val = t.client().calculate_withdrawal(&1_000);
     assert_eq!(val, 1_085);
+}
+
+#[test]
+fn test_distribute_interest_emits_interest_distributed_event() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 1_000);
+    t.client().deposit(&provider, &1_000);
+
+    t.mint(&t.contract_id, 100);
+    t.client().distribute_interest(&t.admin, &100);
+
+    let events: Vec<(Address, Vec<Val>, Val)> = t.env.events().all();
+    let mut found_event = false;
+    for event in events.iter() {
+        let topics = event.1.clone();
+        if let Some(first) = topics.get(0) {
+            let sym: Symbol = first.into_val(&t.env);
+            if sym == symbol_short!("LQINTDST") {
+                found_event = true;
+                // Verify all four fields: (total, lp, protocol, merchant)
+                let data: (i128, i128, i128, i128) = event.2.into_val(&t.env);
+                assert_eq!(data.0, 100); // total_interest
+                assert_eq!(data.1, 85);  // lp_amount (85%)
+                assert_eq!(data.2, 10);  // protocol_amount (10%)
+                assert_eq!(data.3, 5);   // merchant_amount (5%)
+                break;
+            }
+        }
+    }
+    assert!(found_event, "InterestDistributed (LQINTDST) event must be emitted");
+}
+
+#[test]
+fn test_distribute_interest_rounding_remainder_to_merchant() {
+    // 101 tokens: lp=85 (floor), protocol=10 (floor), merchant=6 (remainder avoids dust)
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 10_000);
+    t.client().deposit(&provider, &10_000);
+
+    t.mint(&t.contract_id, 101);
+    t.client().distribute_interest(&t.admin, &101);
+
+    assert_eq!(t.token().balance(&t.treasury), 10);
+    // remainder = 101 - 85 - 10 = 6 goes to merchant (no dust lost to rounding)
+    assert_eq!(t.token().balance(&t.merchant_fund), 6);
 }

--- a/contracts/liquidity-pool-contract/src/tests.rs
+++ b/contracts/liquidity-pool-contract/src/tests.rs
@@ -2529,3 +2529,85 @@ fn test_distribute_interest_admin_and_creditline_both_authorized() {
     t.client().distribute_interest(&t.creditline, &100);
     assert_eq!(t.client().get_pool_stats().total_liquidity, 10_170);
 }
+
+#[test]
+fn test_distribute_interest_increases_share_price() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 1_000);
+    t.client().deposit(&provider, &1_000);
+
+    let before = t.client().get_pool_stats();
+    assert_eq!(before.share_price, 10_000);
+
+    t.mint(&t.contract_id, 100);
+    t.client().distribute_interest(&t.admin, &100);
+
+    let after = t.client().get_pool_stats();
+    // lp_amount = 85 → total_liquidity = 1085 → share_price = 10850 bps
+    assert_eq!(after.share_price, 10_850);
+    assert!(after.share_price > before.share_price);
+}
+
+#[test]
+fn test_distribute_interest_lp_portion_stays_in_pool() {
+    // 85% of interest never leaves the contract — only total_liquidity accounting increases.
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 2_000);
+    t.client().deposit(&provider, &2_000);
+
+    t.mint(&t.contract_id, 500);
+
+    let contract_balance_before = t.token().balance(&t.contract_id);
+    t.client().distribute_interest(&t.admin, &500);
+    let contract_balance_after = t.token().balance(&t.contract_id);
+
+    // 85% of 500 = 425 stayed in pool; only 75 (15%) transferred out
+    let lp_amount = 500i128 * 8500 / 10000; // 425
+    let expected_outflow = 500 - lp_amount; // 75
+    assert_eq!(contract_balance_before - contract_balance_after, expected_outflow);
+}
+
+#[test]
+fn test_distribute_interest_multiple_calls_compound_share_value() {
+    // Repeated distribute_interest calls should linearly increase total_liquidity.
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 1_000);
+    t.client().deposit(&provider, &1_000);
+
+    for _ in 0..3 {
+        t.mint(&t.contract_id, 100);
+        t.client().distribute_interest(&t.admin, &100);
+    }
+
+    // After 3 calls: 1000 + 3*85 = 1255; share_price = 12550
+    let stats = t.client().get_pool_stats();
+    assert_eq!(stats.total_liquidity, 1_255);
+    assert_eq!(stats.share_price, 12_550);
+}
+
+#[test]
+fn test_distribute_interest_proportional_to_multiple_lps() {
+    // Each LP's share value must increase proportionally regardless of
+    // how many providers are in the pool.
+    let t = TestEnv::setup();
+    let provider_a = Address::generate(&t.env);
+    let provider_b = Address::generate(&t.env);
+    let provider_c = Address::generate(&t.env);
+
+    for p in [&provider_a, &provider_b, &provider_c] {
+        t.mint(p, 1_000);
+        t.client().deposit(p, &1_000);
+    }
+
+    // Distribute 300 tokens: lp = 255 stays in pool
+    t.mint(&t.contract_id, 300);
+    t.client().distribute_interest(&t.admin, &300);
+
+    // total_liquidity = 3255, total_shares = 3000
+    // Each LP (1000 shares of 3000): 1000 * 3255 / 3000 = 1085
+    let val = t.client().calculate_withdrawal(&1_000);
+    assert_eq!(val, 1_085);
+}

--- a/contracts/liquidity-pool-contract/src/tests.rs
+++ b/contracts/liquidity-pool-contract/src/tests.rs
@@ -2448,3 +2448,84 @@ fn test_receive_guarantee_blocked_when_paused() {
     t.mint(&t.creditline, 100);
     t.client().receive_guarantee(&t.creditline, &100);
 }
+
+// ─── distribute_interest public entrypoint (SC-17) ───────────────────────────
+
+#[test]
+fn test_distribute_interest_called_by_admin_splits_fees_correctly() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 10_000);
+    t.client().deposit(&provider, &10_000);
+
+    t.mint(&t.contract_id, 1_000);
+    t.client().distribute_interest(&t.admin, &1_000);
+
+    let stats = t.client().get_pool_stats();
+    assert_eq!(stats.total_liquidity, 10_850);
+    assert_eq!(t.token().balance(&t.treasury), 100);
+    assert_eq!(t.token().balance(&t.merchant_fund), 50);
+}
+
+#[test]
+fn test_distribute_interest_called_by_creditline_splits_fees_correctly() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 5_000);
+    t.client().deposit(&provider, &5_000);
+
+    t.mint(&t.contract_id, 200);
+    t.client().distribute_interest(&t.creditline, &200);
+
+    let stats = t.client().get_pool_stats();
+    assert_eq!(stats.total_liquidity, 5_170);
+    assert_eq!(t.token().balance(&t.treasury), 20);
+    assert_eq!(t.token().balance(&t.merchant_fund), 10);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_distribute_interest_unauthorized_caller_fails() {
+    let t = TestEnv::setup();
+    let intruder = Address::generate(&t.env);
+    t.client().distribute_interest(&intruder, &100);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_distribute_interest_zero_amount_fails() {
+    let t = TestEnv::setup();
+    t.client().distribute_interest(&t.admin, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_distribute_interest_negative_amount_fails() {
+    let t = TestEnv::setup();
+    t.client().distribute_interest(&t.admin, &-500);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_distribute_interest_blocked_when_paused() {
+    let t = TestEnv::setup();
+    t.client().pause(&t.admin);
+    t.mint(&t.contract_id, 100);
+    t.client().distribute_interest(&t.admin, &100);
+}
+
+#[test]
+fn test_distribute_interest_admin_and_creditline_both_authorized() {
+    let t = TestEnv::setup();
+    let provider = Address::generate(&t.env);
+    t.mint(&provider, 10_000);
+    t.client().deposit(&provider, &10_000);
+
+    t.mint(&t.contract_id, 100);
+    t.client().distribute_interest(&t.admin, &100);
+    assert_eq!(t.client().get_pool_stats().total_liquidity, 10_085);
+
+    t.mint(&t.contract_id, 100);
+    t.client().distribute_interest(&t.creditline, &100);
+    assert_eq!(t.client().get_pool_stats().total_liquidity, 10_170);
+}

--- a/contracts/liquidity-pool-contract/src/types.rs
+++ b/contracts/liquidity-pool-contract/src/types.rs
@@ -15,7 +15,8 @@ pub struct PoolStats {
 // Fee split constants (basis points, sum = 10000)
 pub const LP_FEE_BPS: i128 = 8500; // 85% to liquidity providers
 pub const PROTOCOL_FEE_BPS: i128 = 1000; // 10% to protocol treasury
-pub const MERCHANT_FEE_BPS: i128 = 500; // 5% to merchant incentive fund
+#[allow(dead_code)]
+pub const MERCHANT_FEE_BPS: i128 = 500; // 5% to merchant incentive fund (used as remainder to avoid rounding loss)
 pub const TOTAL_BPS: i128 = 10000;
 
 /// Minimum deposit / withdrawal to prevent rounding exploits


### PR DESCRIPTION
## Summary

- Implements the `distribute_interest()` public entrypoint that can be called directly by the admin or the CreditLine contract, routing interest to the fee-split logic (85% LP / 10% protocol / 5% merchant)
- Adds `#[allow(dead_code)]` to `MERCHANT_FEE_BPS` constant — the merchant amount is computed as a remainder to avoid rounding dust, so the BPS constant serves as documentation only
- Adds **13 new tests** covering the `distribute_interest` public entrypoint across three areas:
  - **Access control**: admin authorized, creditline authorized, unauthorized caller rejected, zero/negative amounts rejected, paused contract rejected
  - **Fee split & LP accounting**: LP portion stays in the pool (no transfer), share price increases correctly, multiple calls compound linearly, proportional benefit across multiple LPs
  - **Event emission**: `LQINTDST` event emitted with correct `(total, lp, protocol, merchant)` payload; rounding remainder goes to merchant fund (no dust lost)

## Test plan

- [x] `cargo test --locked -p liquidity-pool-contract` — 98 tests pass, 0 failed
- [x] All 4 original SC-17 tasks from the issue are covered:
  - `distribute_interest()` function callable by admin/creditline ✅
  - Interest from repayments increases share value (`total_liquidity` grows) ✅
  - Fee distribution: 85% LP / 10% protocol / 5% merchant ✅
  - `InterestDistributed` event emitted with full payload ✅



# Closes #72