### PR TITLE
feat: implement adapter-trustless-contract

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Build WASM
       run: cargo build -p reputation-contract --target wasm32-unknown-unknown --release
 
+    - name: Build adapter-trustless-contract WASM
+      run: cargo build -p adapter-trustless-contract --target wasm32-unknown-unknown --release
+
   test:
     name: Test Contracts
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "contracts/parameters-contract",
     "contracts/merchant-registry-contract",
     "contracts/liquidity-pool-contract",
-    "contracts/lp-contract"
+    "contracts/lp-contract",
+    "contracts/adapter-trustless-contract"
 ]
 resolver = "2"
 

--- a/contracts/adapter-trustless-contract/Cargo.toml
+++ b/contracts/adapter-trustless-contract/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "adapter-trustless-contract"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/adapter-trustless-contract/src/access.rs
+++ b/contracts/adapter-trustless-contract/src/access.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::{panic_with_error, Address, Env};
+
+use crate::errors::AdapterError;
+use crate::storage;
+
+/// Panics unless `caller` is the admin.
+pub fn require_admin(env: &Env, caller: &Address) {
+    if &storage::get_admin(env) != caller {
+        panic_with_error!(env, AdapterError::NotAdmin);
+    }
+}
+
+/// Panics unless `caller` is the registered CreditLine contract.
+pub fn require_creditline(env: &Env, caller: &Address) {
+    if &storage::get_creditline(env) != caller {
+        panic_with_error!(env, AdapterError::NotCreditLine);
+    }
+}

--- a/contracts/adapter-trustless-contract/src/errors.rs
+++ b/contracts/adapter-trustless-contract/src/errors.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::contracterror;
+
+/// Error codes for the adapter-trustless-contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AdapterError {
+    /// Caller is not the admin.
+    NotAdmin = 1,
+    /// Caller is not the registered CreditLine contract.
+    NotCreditLine = 2,
+    /// No escrow entry exists for the given loan ID.
+    EscrowNotFound = 3,
+    /// The escrow entry is not in the expected status for this operation.
+    InvalidStatus = 4,
+    /// Token amount must be greater than zero.
+    InvalidAmount = 5,
+    /// Contract has already been initialised.
+    AlreadyInitialized = 6,
+}

--- a/contracts/adapter-trustless-contract/src/events.rs
+++ b/contracts/adapter-trustless-contract/src/events.rs
@@ -1,0 +1,23 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+const ESCROW_LOCKED: Symbol = symbol_short!("ESCRWLCK");
+const ESCROW_RELEASED: Symbol = symbol_short!("ESCRWRLS");
+const ESCROW_SEIZED: Symbol = symbol_short!("ESCRWSZD");
+
+/// Emitted when a guarantee is locked into escrow.
+pub fn emit_locked(env: &Env, loan_id: u64, borrower: &Address, amount: i128) {
+    env.events()
+        .publish((ESCROW_LOCKED, loan_id), (borrower, amount));
+}
+
+/// Emitted when a guarantee is released back to the borrower.
+pub fn emit_released(env: &Env, loan_id: u64, borrower: &Address, amount: i128) {
+    env.events()
+        .publish((ESCROW_RELEASED, loan_id), (borrower, amount));
+}
+
+/// Emitted when a guarantee is seized and forwarded to the liquidity pool.
+pub fn emit_seized(env: &Env, loan_id: u64, pool: &Address, amount: i128) {
+    env.events()
+        .publish((ESCROW_SEIZED, loan_id), (pool, amount));
+}

--- a/contracts/adapter-trustless-contract/src/lib.rs
+++ b/contracts/adapter-trustless-contract/src/lib.rs
@@ -26,6 +26,7 @@ impl AdapterTrustlessContract {
         if storage::has_admin(&env) {
             panic_with_error!(&env, AdapterError::AlreadyInitialized);
         }
+        admin.require_auth();
         storage::set_admin(&env, &admin);
         storage::set_creditline(&env, &creditline);
         storage::set_token(&env, &token);

--- a/contracts/adapter-trustless-contract/src/lib.rs
+++ b/contracts/adapter-trustless-contract/src/lib.rs
@@ -1,0 +1,158 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env};
+
+mod access;
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+pub use errors::AdapterError;
+pub use types::{EscrowEntry, EscrowStatus};
+
+/// Trustless escrow adapter contract.
+///
+/// Holds borrower guarantee deposits for the duration of a loan and
+/// releases or seizes them on instruction from the registered CreditLine contract.
+#[contract]
+pub struct AdapterTrustlessContract;
+
+#[contractimpl]
+impl AdapterTrustlessContract {
+    /// Initialise the contract.
+    ///
+    /// Must be called exactly once before any other function.
+    pub fn initialize(env: Env, admin: Address, creditline: Address, token: Address) {
+        if storage::has_admin(&env) {
+            panic_with_error!(&env, AdapterError::AlreadyInitialized);
+        }
+        storage::set_admin(&env, &admin);
+        storage::set_creditline(&env, &creditline);
+        storage::set_token(&env, &token);
+    }
+
+    // ── Admin operations ────────────────────────────────────────────────────
+
+    /// Transfer admin to a new address.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let current = storage::get_admin(&env);
+        current.require_auth();
+        access::require_admin(&env, &current);
+        storage::set_admin(&env, &new_admin);
+    }
+
+    /// Update the registered CreditLine contract address.
+    ///
+    /// Requires admin authorisation.
+    pub fn set_creditline(env: Env, admin: Address, creditline: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+        storage::set_creditline(&env, &creditline);
+    }
+
+    // ── Escrow lifecycle (called by CreditLine) ──────────────────────────────
+
+    /// Lock `amount` tokens from `borrower` as guarantee for `loan_id`.
+    ///
+    /// Transfers tokens from `borrower` to this contract and records the escrow.
+    /// Requires authorisation from the registered CreditLine contract.
+    pub fn lock_guarantee(
+        env: Env,
+        creditline: Address,
+        loan_id: u64,
+        borrower: Address,
+        amount: i128,
+    ) {
+        creditline.require_auth();
+        access::require_creditline(&env, &creditline);
+
+        if amount <= 0 {
+            panic_with_error!(&env, AdapterError::InvalidAmount);
+        }
+        if storage::get_escrow(&env, loan_id).is_some() {
+            panic_with_error!(&env, AdapterError::InvalidStatus);
+        }
+
+        let token_client = token::Client::new(&env, &storage::get_token(&env));
+        token_client.transfer(&borrower, &env.current_contract_address(), &amount);
+
+        storage::set_escrow(
+            &env,
+            loan_id,
+            &EscrowEntry {
+                borrower: borrower.clone(),
+                amount,
+                status: EscrowStatus::Locked,
+            },
+        );
+
+        events::emit_locked(&env, loan_id, &borrower, amount);
+    }
+
+    /// Release the guarantee back to the borrower after successful repayment.
+    ///
+    /// Requires authorisation from the registered CreditLine contract.
+    pub fn release_guarantee(env: Env, creditline: Address, loan_id: u64) {
+        creditline.require_auth();
+        access::require_creditline(&env, &creditline);
+
+        let mut entry = storage::get_escrow(&env, loan_id)
+            .unwrap_or_else(|| panic_with_error!(&env, AdapterError::EscrowNotFound));
+
+        if entry.status != EscrowStatus::Locked {
+            panic_with_error!(&env, AdapterError::InvalidStatus);
+        }
+
+        let token_client = token::Client::new(&env, &storage::get_token(&env));
+        token_client.transfer(&env.current_contract_address(), &entry.borrower, &entry.amount);
+
+        entry.status = EscrowStatus::Released;
+        storage::set_escrow(&env, loan_id, &entry);
+
+        events::emit_released(&env, loan_id, &entry.borrower, entry.amount);
+    }
+
+    /// Seize the guarantee and forward it to the liquidity pool on default.
+    ///
+    /// Requires authorisation from the registered CreditLine contract.
+    pub fn seize_guarantee(env: Env, creditline: Address, loan_id: u64, pool: Address) {
+        creditline.require_auth();
+        access::require_creditline(&env, &creditline);
+
+        let mut entry = storage::get_escrow(&env, loan_id)
+            .unwrap_or_else(|| panic_with_error!(&env, AdapterError::EscrowNotFound));
+
+        if entry.status != EscrowStatus::Locked {
+            panic_with_error!(&env, AdapterError::InvalidStatus);
+        }
+
+        let token_client = token::Client::new(&env, &storage::get_token(&env));
+        token_client.transfer(&env.current_contract_address(), &pool, &entry.amount);
+
+        entry.status = EscrowStatus::Seized;
+        storage::set_escrow(&env, loan_id, &entry);
+
+        events::emit_seized(&env, loan_id, &pool, entry.amount);
+    }
+
+    // ── Queries ─────────────────────────────────────────────────────────────
+
+    /// Return the escrow entry for a given loan ID.
+    pub fn get_escrow(env: Env, loan_id: u64) -> EscrowEntry {
+        storage::get_escrow(&env, loan_id)
+            .unwrap_or_else(|| panic_with_error!(&env, AdapterError::EscrowNotFound))
+    }
+
+    /// Return the current admin address.
+    pub fn get_admin(env: Env) -> Address {
+        storage::get_admin(&env)
+    }
+
+    /// Return the registered CreditLine contract address.
+    pub fn get_creditline(env: Env) -> Address {
+        storage::get_creditline(&env)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/contracts/adapter-trustless-contract/src/storage.rs
+++ b/contracts/adapter-trustless-contract/src/storage.rs
@@ -1,0 +1,65 @@
+use soroban_sdk::{symbol_short, Address, Env, Map, Symbol};
+
+use crate::types::EscrowEntry;
+
+pub const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
+pub const CREDITLINE_KEY: Symbol = symbol_short!("CREDITLN");
+pub const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
+pub const ESCROWS_KEY: Symbol = symbol_short!("ESCROWS");
+
+// --- Admin ---
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&ADMIN_KEY).unwrap()
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&ADMIN_KEY, admin);
+}
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&ADMIN_KEY)
+}
+
+// --- CreditLine ---
+
+pub fn get_creditline(env: &Env) -> Address {
+    env.storage().instance().get(&CREDITLINE_KEY).unwrap()
+}
+
+pub fn set_creditline(env: &Env, creditline: &Address) {
+    env.storage().instance().set(&CREDITLINE_KEY, creditline);
+}
+
+// --- Token ---
+
+pub fn get_token(env: &Env) -> Address {
+    env.storage().instance().get(&TOKEN_KEY).unwrap()
+}
+
+pub fn set_token(env: &Env, token: &Address) {
+    env.storage().instance().set(&TOKEN_KEY, token);
+}
+
+// --- Escrow entries ---
+
+fn get_escrows(env: &Env) -> Map<u64, EscrowEntry> {
+    env.storage()
+        .persistent()
+        .get(&ESCROWS_KEY)
+        .unwrap_or_else(|| Map::new(env))
+}
+
+fn save_escrows(env: &Env, map: &Map<u64, EscrowEntry>) {
+    env.storage().persistent().set(&ESCROWS_KEY, map);
+}
+
+pub fn get_escrow(env: &Env, loan_id: u64) -> Option<EscrowEntry> {
+    get_escrows(env).get(loan_id)
+}
+
+pub fn set_escrow(env: &Env, loan_id: u64, entry: &EscrowEntry) {
+    let mut map = get_escrows(env);
+    map.set(loan_id, entry.clone());
+    save_escrows(env, &map);
+}

--- a/contracts/adapter-trustless-contract/src/storage.rs
+++ b/contracts/adapter-trustless-contract/src/storage.rs
@@ -1,11 +1,11 @@
-use soroban_sdk::{symbol_short, Address, Env, Map, Symbol};
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
 use crate::types::EscrowEntry;
 
 pub const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 pub const CREDITLINE_KEY: Symbol = symbol_short!("CREDITLN");
 pub const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
-pub const ESCROWS_KEY: Symbol = symbol_short!("ESCROWS");
+pub const ESCROW_PREFIX: Symbol = symbol_short!("ESCROW");
 
 // --- Admin ---
 
@@ -43,23 +43,12 @@ pub fn set_token(env: &Env, token: &Address) {
 
 // --- Escrow entries ---
 
-fn get_escrows(env: &Env) -> Map<u64, EscrowEntry> {
-    env.storage()
-        .persistent()
-        .get(&ESCROWS_KEY)
-        .unwrap_or_else(|| Map::new(env))
-}
-
-fn save_escrows(env: &Env, map: &Map<u64, EscrowEntry>) {
-    env.storage().persistent().set(&ESCROWS_KEY, map);
-}
-
 pub fn get_escrow(env: &Env, loan_id: u64) -> Option<EscrowEntry> {
-    get_escrows(env).get(loan_id)
+    env.storage().persistent().get(&(ESCROW_PREFIX, loan_id))
 }
 
 pub fn set_escrow(env: &Env, loan_id: u64, entry: &EscrowEntry) {
-    let mut map = get_escrows(env);
-    map.set(loan_id, entry.clone());
-    save_escrows(env, &map);
+    env.storage()
+        .persistent()
+        .set(&(ESCROW_PREFIX, loan_id), entry);
 }

--- a/contracts/adapter-trustless-contract/src/tests.rs
+++ b/contracts/adapter-trustless-contract/src/tests.rs
@@ -1,0 +1,210 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+use crate::{AdapterTrustlessContract, AdapterTrustlessContractClient, EscrowStatus};
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+struct TestCtx {
+    env: Env,
+    client: AdapterTrustlessContractClient<'static>,
+    admin: Address,
+    creditline: Address,
+    token: Address,
+}
+
+fn setup() -> TestCtx {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creditline = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let contract_id = env.register(AdapterTrustlessContract, ());
+    let client = AdapterTrustlessContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &creditline, &token);
+
+    TestCtx { env, client, admin, creditline, token }
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    // StellarAssetClient mint requires the token admin auth, covered by mock_all_auths
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+// ── Initialisation ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_sets_admin_and_creditline() {
+    let ctx = setup();
+    assert_eq!(ctx.client.get_admin(), ctx.admin);
+    assert_eq!(ctx.client.get_creditline(), ctx.creditline);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyInitialized")]
+fn test_initialize_twice_panics() {
+    let ctx = setup();
+    ctx.client.initialize(&ctx.admin, &ctx.creditline, &ctx.token);
+}
+
+// ── Admin operations ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_admin_transfers_admin() {
+    let ctx = setup();
+    let new_admin = Address::generate(&ctx.env);
+    ctx.client.set_admin(&new_admin);
+    assert_eq!(ctx.client.get_admin(), new_admin);
+}
+
+#[test]
+fn test_set_creditline_updates_creditline() {
+    let ctx = setup();
+    let new_cl = Address::generate(&ctx.env);
+    ctx.client.set_creditline(&ctx.admin, &new_cl);
+    assert_eq!(ctx.client.get_creditline(), new_cl);
+}
+
+#[test]
+#[should_panic(expected = "NotAdmin")]
+fn test_set_creditline_rejects_non_admin() {
+    let ctx = setup();
+    let attacker = Address::generate(&ctx.env);
+    let new_cl = Address::generate(&ctx.env);
+    ctx.client.set_creditline(&attacker, &new_cl);
+}
+
+// ── lock_guarantee ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_lock_guarantee_stores_entry() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+
+    let entry = ctx.client.get_escrow(&1u64);
+    assert_eq!(entry.borrower, borrower);
+    assert_eq!(entry.amount, 200);
+    assert_eq!(entry.status, EscrowStatus::Locked);
+}
+
+#[test]
+#[should_panic(expected = "NotCreditLine")]
+fn test_lock_guarantee_rejects_non_creditline() {
+    let ctx = setup();
+    let attacker = Address::generate(&ctx.env);
+    let borrower = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+    ctx.client.lock_guarantee(&attacker, &1u64, &borrower, &200i128);
+}
+
+#[test]
+#[should_panic(expected = "InvalidAmount")]
+fn test_lock_guarantee_rejects_zero_amount() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "InvalidStatus")]
+fn test_lock_guarantee_rejects_duplicate_loan_id() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 400);
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+}
+
+// ── release_guarantee ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_release_guarantee_returns_funds_to_borrower() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+    ctx.client.release_guarantee(&ctx.creditline, &1u64);
+
+    let entry = ctx.client.get_escrow(&1u64);
+    assert_eq!(entry.status, EscrowStatus::Released);
+
+    let balance = TokenClient::new(&ctx.env, &ctx.token).balance(&borrower);
+    assert_eq!(balance, 200);
+}
+
+#[test]
+#[should_panic(expected = "InvalidStatus")]
+fn test_release_guarantee_twice_panics() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+    ctx.client.release_guarantee(&ctx.creditline, &1u64);
+    ctx.client.release_guarantee(&ctx.creditline, &1u64);
+}
+
+#[test]
+#[should_panic(expected = "EscrowNotFound")]
+fn test_release_guarantee_unknown_loan_panics() {
+    let ctx = setup();
+    ctx.client.release_guarantee(&ctx.creditline, &99u64);
+}
+
+// ── seize_guarantee ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_seize_guarantee_forwards_funds_to_pool() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    let pool = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+    ctx.client.seize_guarantee(&ctx.creditline, &1u64, &pool);
+
+    let entry = ctx.client.get_escrow(&1u64);
+    assert_eq!(entry.status, EscrowStatus::Seized);
+
+    let pool_balance = TokenClient::new(&ctx.env, &ctx.token).balance(&pool);
+    assert_eq!(pool_balance, 200);
+}
+
+#[test]
+#[should_panic(expected = "InvalidStatus")]
+fn test_seize_after_release_panics() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    let pool = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+    ctx.client.release_guarantee(&ctx.creditline, &1u64);
+    ctx.client.seize_guarantee(&ctx.creditline, &1u64, &pool);
+}
+
+#[test]
+#[should_panic(expected = "NotCreditLine")]
+fn test_seize_guarantee_rejects_non_creditline() {
+    let ctx = setup();
+    let borrower = Address::generate(&ctx.env);
+    let pool = Address::generate(&ctx.env);
+    let attacker = Address::generate(&ctx.env);
+    mint(&ctx.env, &ctx.token, &borrower, 200);
+    ctx.client.lock_guarantee(&ctx.creditline, &1u64, &borrower, &200i128);
+    ctx.client.seize_guarantee(&attacker, &1u64, &pool);
+}

--- a/contracts/adapter-trustless-contract/src/types.rs
+++ b/contracts/adapter-trustless-contract/src/types.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Status of a guarantee escrow entry.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscrowStatus {
+    /// Funds are held in escrow.
+    Locked,
+    /// Funds were returned to the borrower after successful repayment.
+    Released,
+    /// Funds were forwarded to the liquidity pool after default.
+    Seized,
+}
+
+/// A single guarantee escrow record, keyed by `loan_id`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EscrowEntry {
+    /// The borrower whose guarantee is held.
+    pub borrower: Address,
+    /// The locked token amount.
+    pub amount: i128,
+    /// Current lifecycle status.
+    pub status: EscrowStatus,
+}

--- a/docs/adapter-trustless-contract-design.md
+++ b/docs/adapter-trustless-contract-design.md
@@ -5,9 +5,10 @@
 The `adapter-trustless-contract` is a **trustless escrow and payment adapter** within the TrustUp BNPL system. It acts as the neutral on-chain intermediary that:
 
 1. Holds the borrower's 20% guarantee deposit during the loan lifecycle
-2. Forwards the remaining 80% purchase funds to the merchant at loan creation
-3. On successful repayment: returns the guarantee to the borrower
-4. On default: forwards the forfeited guarantee to the liquidity pool
+2. On successful repayment: returns the guarantee to the borrower
+3. On default: forwards the forfeited guarantee to the liquidity pool
+
+The remaining 80% purchase funds are forwarded to the merchant by the CreditLine contract at loan creation; this contract only ever holds the guarantee deposit.
 
 This contract removes the need to trust either the CreditLine contract or any off-chain party with the guarantee funds. All fund movements are encoded in smart contract logic and emitted as auditable on-chain events.
 

--- a/docs/adapter-trustless-contract-design.md
+++ b/docs/adapter-trustless-contract-design.md
@@ -1,0 +1,102 @@
+# Adapter Trustless Contract — Design Document
+
+## Purpose
+
+The `adapter-trustless-contract` is a **trustless escrow and payment adapter** within the TrustUp BNPL system. It acts as the neutral on-chain intermediary that:
+
+1. Holds the borrower's 20% guarantee deposit during the loan lifecycle
+2. Forwards the remaining 80% purchase funds to the merchant at loan creation
+3. On successful repayment: returns the guarantee to the borrower
+4. On default: forwards the forfeited guarantee to the liquidity pool
+
+This contract removes the need to trust either the CreditLine contract or any off-chain party with the guarantee funds. All fund movements are encoded in smart contract logic and emitted as auditable on-chain events.
+
+## Problem It Solves
+
+Without this contract, the CreditLine contract would directly hold user guarantee funds. This creates a single point of trust: users must trust the CreditLine contract's admin not to misuse or drain the escrow. The adapter-trustless-contract separates escrow logic from credit logic, minimising blast radius if either contract is compromised and making the guarantee mechanism transparent and auditable.
+
+## Design
+
+### Core Concepts
+
+- **Escrow**: Guarantee funds are locked by `lock_guarantee` at loan creation, identified by `loan_id`.
+- **Release**: Only the registered `creditline` contract can call `release_guarantee` (on repayment) or `seize_guarantee` (on default).
+- **Token**: A single SEP-41 token address (e.g., USDC) is configured at initialisation.
+
+### State
+
+```
+Admin              → Address (instance)
+CreditLine         → Address (instance)
+Token              → Address (instance)
+Escrow(loan_id)    → EscrowEntry { borrower, amount, status } (persistent)
+```
+
+### Public API
+
+```rust
+// Initialisation
+fn initialize(env, admin, creditline, token)
+
+// Admin operations
+fn set_admin(env, new_admin)
+fn set_creditline(env, admin, creditline)
+
+// Escrow lifecycle (called by CreditLine)
+fn lock_guarantee(env, creditline, loan_id, borrower, amount)
+fn release_guarantee(env, creditline, loan_id)   // repayment → back to borrower
+fn seize_guarantee(env, creditline, loan_id, pool) // default → to liquidity pool
+
+// Queries
+fn get_escrow(env, loan_id) -> EscrowEntry
+fn get_admin(env) -> Address
+fn get_creditline(env) -> Address
+```
+
+### Events
+
+- `ESCRWLCK`: Guarantee locked (`loan_id`, `borrower`, `amount`)
+- `ESCRWRLS`: Guarantee released to borrower (`loan_id`, `borrower`, `amount`)
+- `ESCRWSZD`: Guarantee seized to pool (`loan_id`, `pool`, `amount`)
+
+### Access Control
+
+| Caller     | Allowed operations                             |
+|------------|------------------------------------------------|
+| Admin      | `set_admin`, `set_creditline`                  |
+| CreditLine | `lock_guarantee`, `release_guarantee`, `seize_guarantee` |
+| Anyone     | `get_escrow`, `get_admin`, `get_creditline`    |
+
+### Escrow Status Machine
+
+```
+(none) ──lock_guarantee──→ Locked
+Locked ──release_guarantee──→ Released
+Locked ──seize_guarantee──→ Seized
+```
+
+Attempting any invalid transition panics with `InvalidStatus`.
+
+## Integration with TrustUp System
+
+```
+CreditLine.create_loan()
+    └─→ AdapterTrustless.lock_guarantee(loan_id, borrower, guarantee)
+            └─→ Token.transfer(borrower → adapter)
+
+CreditLine.repay_loan() [fully repaid]
+    └─→ AdapterTrustless.release_guarantee(loan_id)
+            └─→ Token.transfer(adapter → borrower)
+
+CreditLine.mark_defaulted()
+    └─→ AdapterTrustless.seize_guarantee(loan_id, pool)
+            └─→ Token.transfer(adapter → liquidity_pool)
+```
+
+## Security Considerations
+
+- Only the registered CreditLine address can trigger escrow transitions
+- Token address is set once at initialisation (immutable in practice)
+- Safe arithmetic on all token amounts
+- Status guard prevents double-release or double-seize
+- Admin cannot touch escrowed funds directly

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -415,3 +415,90 @@ All contracts follow upgrade pattern:
 - [Reputation Contract Source](../../contracts/reputation-contract/src/lib.rs)
 - [Roadmap](../ROADMAP.md) - Implementation timeline
 - [Storage Patterns](storage-patterns.md) - Storage best practices
+
+---
+
+## Adapter Trustless Contract ✅
+
+**Status**: Implemented and tested
+
+**Purpose**: Trustless escrow adapter that holds the borrower's 20% guarantee deposit for the lifetime of a loan and releases or seizes it based on loan outcome.
+
+### Architecture
+
+**State**:
+```rust
+// Instance storage
+Admin      → Address
+CreditLine → Address
+Token      → Address
+
+// Persistent storage
+Escrows    → Map<u64, EscrowEntry>
+```
+
+```rust
+#[contracttype]
+pub struct EscrowEntry {
+    pub borrower: Address,
+    pub amount: i128,
+    pub status: EscrowStatus,  // Locked | Released | Seized
+}
+```
+
+**Public API**:
+```rust
+// Initialisation
+pub fn initialize(env: Env, admin: Address, creditline: Address, token: Address)
+
+// Admin
+pub fn set_admin(env: Env, new_admin: Address)
+pub fn set_creditline(env: Env, admin: Address, creditline: Address)
+
+// Escrow lifecycle (CreditLine-only)
+pub fn lock_guarantee(env: Env, creditline: Address, loan_id: u64, borrower: Address, amount: i128)
+pub fn release_guarantee(env: Env, creditline: Address, loan_id: u64)
+pub fn seize_guarantee(env: Env, creditline: Address, loan_id: u64, pool: Address)
+
+// Queries
+pub fn get_escrow(env: Env, loan_id: u64) -> EscrowEntry
+pub fn get_admin(env: Env) -> Address
+pub fn get_creditline(env: Env) -> Address
+```
+
+**Events**:
+- `ESCRWLCK`: Guarantee locked (`loan_id`, `borrower`, `amount`)
+- `ESCRWRLS`: Guarantee released to borrower (`loan_id`, `borrower`, `amount`)
+- `ESCRWSZD`: Guarantee seized to liquidity pool (`loan_id`, `pool`, `amount`)
+
+**Access Control**:
+
+| Caller     | Allowed operations                                                |
+|------------|-------------------------------------------------------------------|
+| Admin      | `set_admin`, `set_creditline`                                     |
+| CreditLine | `lock_guarantee`, `release_guarantee`, `seize_guarantee`          |
+| Anyone     | `get_escrow`, `get_admin`, `get_creditline`                       |
+
+**Escrow Status Machine**:
+```
+(none) ──lock_guarantee──→ Locked
+Locked ──release_guarantee──→ Released   (repayment success)
+Locked ──seize_guarantee──→ Seized       (default)
+```
+
+**Integration**:
+```
+CreditLine.create_loan()
+    └─→ AdapterTrustless.lock_guarantee(loan_id, borrower, guarantee)
+            └─→ Token.transfer(borrower → adapter)
+
+CreditLine.repay_loan() [fully repaid]
+    └─→ AdapterTrustless.release_guarantee(loan_id)
+            └─→ Token.transfer(adapter → borrower)
+
+CreditLine.mark_defaulted()
+    └─→ AdapterTrustless.seize_guarantee(loan_id, pool)
+            └─→ Token.transfer(adapter → liquidity_pool)
+```
+
+**Design document**: [adapter-trustless-contract-design.md](../adapter-trustless-contract-design.md)


### PR DESCRIPTION
## Summary

Implements the `adapter-trustless-contract` — a trustless escrow adapter that holds borrower guarantee deposits for the full BNPL loan lifecycle and releases or seizes them based on loan outcome.

## Design

The contract acts as a neutral on-chain escrow between borrowers, the CreditLine contract, and the liquidity pool:

- **lock_guarantee**: CreditLine calls this at loan creation; transfers the 20% deposit from borrower into the contract
- **release_guarantee**: CreditLine calls this on successful repayment; returns the deposit to the borrower
- **seize_guarantee**: CreditLine calls this on default; forwards the forfeited deposit to the liquidity pool

Only the registered CreditLine contract address can trigger escrow state transitions. Admin cannot touch escrowed funds.

## Changes

| File | Change |
|------|--------|
| `contracts/adapter-trustless-contract/Cargo.toml` | New contract package |
| `contracts/adapter-trustless-contract/src/lib.rs` | Contract entry point, all public functions |
| `contracts/adapter-trustless-contract/src/types.rs` | `EscrowEntry`, `EscrowStatus` |
| `contracts/adapter-trustless-contract/src/errors.rs` | `AdapterError` enum |
| `contracts/adapter-trustless-contract/src/storage.rs` | Instance + persistent storage helpers |
| `contracts/adapter-trustless-contract/src/access.rs` | `require_admin`, `require_creditline` |
| `contracts/adapter-trustless-contract/src/events.rs` | `ESCRWLCK`, `ESCRWRLS`, `ESCRWSZD` |
| `contracts/adapter-trustless-contract/src/tests.rs` | 15 unit tests (full lifecycle + error paths) |
| `Cargo.toml` | Add to workspace members |
| `.github/workflows/contracts-ci.yml` | Add WASM build step |
| `docs/adapter-trustless-contract-design.md` | Design document |
| `docs/architecture/contracts.md` | Contract reference entry |

## Tests

15 unit tests covering:
- Initialisation (idempotency guard)
- Admin operations (transfer, access control)
- `lock_guarantee`: happy path, wrong caller, zero amount, duplicate loan ID
- `release_guarantee`: happy path, double-release guard, unknown loan ID
- `seize_guarantee`: happy path, seize-after-release guard, wrong caller

## Integration

```
CreditLine.create_loan()
    └─→ AdapterTrustless.lock_guarantee(loan_id, borrower, guarantee)

CreditLine.repay_loan() [fully repaid]
    └─→ AdapterTrustless.release_guarantee(loan_id)

CreditLine.mark_defaulted()
    └─→ AdapterTrustless.seize_guarantee(loan_id, pool)
```

Closes #84