### PR TITLE
Implement adapter-trustless-contract as multi-sig timelock gateway

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Build WASM
       run: cargo build -p reputation-contract --target wasm32-unknown-unknown --release
 
+    - name: Build adapter-trustless-contract WASM
+      run: cargo build -p adapter-trustless-contract --target wasm32-unknown-unknown --release
+
   test:
     name: Test Contracts
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "adapter-trustless-contract"
+version = "1.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "contracts/merchant-registry-contract",
     "contracts/liquidity-pool-contract",
     "contracts/lp-contract",
+    "contracts/adapter-trustless-contract",
     "tests/integration"
 ]
 resolver = "2"

--- a/contracts/adapter-trustless-contract/Cargo.toml
+++ b/contracts/adapter-trustless-contract/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "adapter-trustless-contract"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/adapter-trustless-contract/README.md
+++ b/contracts/adapter-trustless-contract/README.md
@@ -1,0 +1,80 @@
+# Adapter Trustless Contract
+
+## Purpose
+
+TrustUp's other contracts (`reputation-contract`, `creditline-contract`,
+`liquidity-pool-contract`, `merchant-registry-contract`, `parameters-contract`) each
+gate sensitive operations (changing an admin, updating a cross-contract address,
+tuning risk parameters) behind a single `admin` address. That admin key is a single
+point of failure and a single point of trust: whoever holds it can unilaterally
+change protocol behavior with no on-chain check.
+
+The adapter-trustless-contract removes that single point of trust. It is a generic
+**M-of-N multi-sig + timelock gateway** that other contracts (or their admins) can
+point their privileged operations through instead of executing them directly:
+
+1. A signer **proposes** an action: the target contract address, the function to
+   call, and its arguments.
+2. Other signers **approve** the action.
+3. Once at least `threshold` signers have approved **and** the configured timelock
+   delay has elapsed since the proposal, anyone can **execute** the action, which
+   invokes the target contract via `Env::invoke_contract`.
+
+No single signer — including the adapter's own admin — can execute a privileged
+call alone. The action, its approvals, and its execution are all public and
+auditable on-chain via events.
+
+## What it does *not* do (out of scope for this issue)
+
+- It does not replace each contract's own `admin` field; contracts must be
+  reconfigured to name the adapter's resolved address (or an address it controls)
+  as their admin/updater if they want its guarantees enforced. That migration is a
+  follow-up once the adapter is reviewed and deployed.
+- It does not interpret or validate the semantics of the calls it forwards — it is
+  a generic relay, not a per-contract policy engine.
+
+## Public API
+
+```rust
+// Setup (once)
+pub fn initialize(env: Env, admin: Address, signers: Vec<Address>, threshold: u32, timelock_secs: u64)
+
+// Proposal lifecycle
+pub fn propose_action(env: Env, proposer: Address, target: Address, function: Symbol, args: Vec<Val>) -> u64
+pub fn approve_action(env: Env, signer: Address, action_id: u64)
+pub fn revoke_approval(env: Env, signer: Address, action_id: u64)
+pub fn execute_action(env: Env, caller: Address, action_id: u64) -> Val
+pub fn cancel_action(env: Env, admin: Address, action_id: u64)
+
+// Signer / config management (admin only)
+pub fn add_signer(env: Env, admin: Address, signer: Address)
+pub fn remove_signer(env: Env, admin: Address, signer: Address)
+pub fn set_threshold(env: Env, admin: Address, threshold: u32)
+pub fn set_timelock(env: Env, admin: Address, timelock_secs: u64)
+
+// Queries
+pub fn get_action(env: Env, action_id: u64) -> Action
+pub fn is_approved(env: Env, action_id: u64) -> bool
+pub fn is_executable(env: Env, action_id: u64) -> bool
+pub fn get_signers(env: Env) -> Vec<Address>
+pub fn get_threshold(env: Env) -> u32
+pub fn get_timelock(env: Env) -> u64
+pub fn get_admin(env: Env) -> Address
+```
+
+## Events
+
+| Topic       | Emitted when                       |
+|-------------|-------------------------------------|
+| `ACTNPROP`  | Action proposed                     |
+| `ACTNAPPRV` | Signer approves an action           |
+| `ACTNREVK`  | Signer revokes their approval       |
+| `ACTNEXEC`  | Action executed                     |
+| `ACTNCANC`  | Admin cancels an action             |
+| `SIGNERADD` | Signer added                        |
+| `SIGNERRM`  | Signer removed                      |
+| `THRESHCHG` | Approval threshold changed          |
+| `TMLOCKCHG` | Timelock delay changed              |
+| `ADMINCHGD` | Admin changed                       |
+
+See `docs/architecture/contracts.md` for the full architecture writeup.

--- a/contracts/adapter-trustless-contract/src/access.rs
+++ b/contracts/adapter-trustless-contract/src/access.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::{panic_with_error, Address, Env};
+
+use crate::errors::AdapterError;
+use crate::storage;
+
+/// Require that the given address is the admin, otherwise panic with NotAdmin error
+pub fn require_admin(env: &Env, caller: &Address) {
+    let admin = storage::get_admin(env);
+
+    if caller != &admin {
+        panic_with_error!(env, AdapterError::NotAdmin);
+    }
+}
+
+/// Require that the given address is an authorized signer, otherwise panic with NotSigner error
+pub fn require_signer(env: &Env, addr: &Address) {
+    if !storage::is_signer(env, addr) {
+        panic_with_error!(env, AdapterError::NotSigner);
+    }
+}

--- a/contracts/adapter-trustless-contract/src/errors.rs
+++ b/contracts/adapter-trustless-contract/src/errors.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::contracterror;
+
+// Error types for the adapter-trustless-contract
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AdapterError {
+    NotAdmin = 1,
+    NotSigner = 2,
+    AlreadyInitialized = 3,
+    EmptySigners = 4,
+    InvalidThreshold = 5,
+    ActionNotFound = 6,
+    ActionAlreadyExecuted = 7,
+    ActionCanceled = 8,
+    AlreadyApproved = 9,
+    ApprovalNotFound = 10,
+    ThresholdNotMet = 11,
+    TimelockNotElapsed = 12,
+    SignerAlreadyExists = 13,
+    SignerNotFound = 14,
+}

--- a/contracts/adapter-trustless-contract/src/events.rs
+++ b/contracts/adapter-trustless-contract/src/events.rs
@@ -1,0 +1,74 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+// Event topics
+const ACTION_PROPOSED: Symbol = symbol_short!("ACTNPROP");
+const ACTION_APPROVED: Symbol = symbol_short!("ACTNAPPRV");
+const APPROVAL_REVOKED: Symbol = symbol_short!("ACTNREVK");
+const ACTION_EXECUTED: Symbol = symbol_short!("ACTNEXEC");
+const ACTION_CANCELED: Symbol = symbol_short!("ACTNCANC");
+const SIGNER_ADDED: Symbol = symbol_short!("SIGNERADD");
+const SIGNER_REMOVED: Symbol = symbol_short!("SIGNERRM");
+const THRESHOLD_CHANGED: Symbol = symbol_short!("THRESHCHG");
+const TIMELOCK_CHANGED: Symbol = symbol_short!("TMLOCKCHG");
+const ADMIN_CHANGED: Symbol = symbol_short!("ADMINCHGD");
+
+/// Emit an action proposed event
+pub fn emit_action_proposed(
+    env: &Env,
+    action_id: u64,
+    proposer: &Address,
+    target: &Address,
+    function: &Symbol,
+) {
+    env.events()
+        .publish((ACTION_PROPOSED, action_id), (proposer, target, function));
+}
+
+/// Emit an action approved event
+pub fn emit_action_approved(env: &Env, action_id: u64, signer: &Address) {
+    env.events().publish((ACTION_APPROVED, action_id), signer);
+}
+
+/// Emit an approval revoked event
+pub fn emit_approval_revoked(env: &Env, action_id: u64, signer: &Address) {
+    env.events().publish((APPROVAL_REVOKED, action_id), signer);
+}
+
+/// Emit an action executed event
+pub fn emit_action_executed(env: &Env, action_id: u64, target: &Address, function: &Symbol) {
+    env.events()
+        .publish((ACTION_EXECUTED, action_id), (target, function));
+}
+
+/// Emit an action canceled event
+pub fn emit_action_canceled(env: &Env, action_id: u64) {
+    env.events().publish((ACTION_CANCELED,), action_id);
+}
+
+/// Emit a signer added event
+pub fn emit_signer_added(env: &Env, signer: &Address) {
+    env.events().publish((SIGNER_ADDED,), signer);
+}
+
+/// Emit a signer removed event
+pub fn emit_signer_removed(env: &Env, signer: &Address) {
+    env.events().publish((SIGNER_REMOVED,), signer);
+}
+
+/// Emit a threshold changed event
+pub fn emit_threshold_changed(env: &Env, old_threshold: u32, new_threshold: u32) {
+    env.events()
+        .publish((THRESHOLD_CHANGED,), (old_threshold, new_threshold));
+}
+
+/// Emit a timelock changed event
+pub fn emit_timelock_changed(env: &Env, old_timelock: u64, new_timelock: u64) {
+    env.events()
+        .publish((TIMELOCK_CHANGED,), (old_timelock, new_timelock));
+}
+
+/// Emit an admin changed event
+pub fn emit_admin_changed(env: &Env, old_admin: &Address, new_admin: &Address) {
+    env.events()
+        .publish((ADMIN_CHANGED,), (old_admin, new_admin));
+}

--- a/contracts/adapter-trustless-contract/src/lib.rs
+++ b/contracts/adapter-trustless-contract/src/lib.rs
@@ -1,0 +1,316 @@
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, symbol_short, Address, Env, Symbol, Val, Vec,
+};
+
+// Module imports
+mod access;
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+// Re-export types for external use
+pub use errors::AdapterError;
+pub use types::Action;
+
+/// Adapter trustless contract structure.
+///
+/// A generic M-of-N multi-sig + timelock gateway: privileged cross-contract calls
+/// are proposed, approved by a threshold of signers, and executed only after a
+/// timelock delay has elapsed, so no single signer (including the admin) can act
+/// unilaterally.
+#[contract]
+pub struct AdapterTrustlessContract;
+
+#[contractimpl]
+impl AdapterTrustlessContract {
+    /// Get the version of this contract
+    pub fn get_version() -> Symbol {
+        symbol_short!("v1_0_0")
+    }
+
+    /// Initialize the adapter with an admin, an initial signer set, an approval
+    /// threshold, and a timelock delay (in seconds).
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        signers: Vec<Address>,
+        threshold: u32,
+        timelock_secs: u64,
+    ) {
+        if storage::has_admin(&env) {
+            panic_with_error!(&env, AdapterError::AlreadyInitialized);
+        }
+        if signers.is_empty() {
+            panic_with_error!(&env, AdapterError::EmptySigners);
+        }
+        if threshold == 0 || threshold > signers.len() {
+            panic_with_error!(&env, AdapterError::InvalidThreshold);
+        }
+
+        admin.require_auth();
+
+        storage::set_admin(&env, &admin);
+        storage::set_signers(&env, &signers);
+        storage::set_threshold(&env, threshold);
+        storage::set_timelock(&env, timelock_secs);
+
+        events::emit_admin_changed(&env, &admin, &admin);
+    }
+
+    /// Propose a cross-contract call. The proposer's approval counts as the first
+    /// vote. Returns the newly assigned action id.
+    pub fn propose_action(
+        env: Env,
+        proposer: Address,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+    ) -> u64 {
+        proposer.require_auth();
+        access::require_signer(&env, &proposer);
+
+        let action_id = storage::next_action_id(&env);
+
+        let mut approvals = Vec::new(&env);
+        approvals.push_back(proposer.clone());
+
+        let action = Action {
+            id: action_id,
+            target: target.clone(),
+            function: function.clone(),
+            args,
+            proposer: proposer.clone(),
+            proposed_at: env.ledger().timestamp(),
+            approvals,
+            executed: false,
+            canceled: false,
+        };
+
+        storage::set_action(&env, &action);
+        events::emit_action_proposed(&env, action_id, &proposer, &target, &function);
+
+        action_id
+    }
+
+    /// Approve a proposed action. Requires authorization from an authorized signer.
+    pub fn approve_action(env: Env, signer: Address, action_id: u64) {
+        signer.require_auth();
+        access::require_signer(&env, &signer);
+
+        let mut action = storage::get_action(&env, action_id);
+        Self::require_pending(&env, &action);
+
+        if action.approvals.contains(&signer) {
+            panic_with_error!(&env, AdapterError::AlreadyApproved);
+        }
+
+        action.approvals.push_back(signer.clone());
+        storage::set_action(&env, &action);
+
+        events::emit_action_approved(&env, action_id, &signer);
+    }
+
+    /// Revoke a previously given approval. Requires authorization from the signer
+    /// who approved.
+    pub fn revoke_approval(env: Env, signer: Address, action_id: u64) {
+        signer.require_auth();
+
+        let mut action = storage::get_action(&env, action_id);
+        Self::require_pending(&env, &action);
+
+        match action.approvals.iter().position(|a| a == signer) {
+            Some(index) => {
+                action.approvals.remove(index as u32);
+            }
+            None => panic_with_error!(&env, AdapterError::ApprovalNotFound),
+        }
+
+        storage::set_action(&env, &action);
+        events::emit_approval_revoked(&env, action_id, &signer);
+    }
+
+    /// Execute an action once it has reached the approval threshold and the
+    /// timelock delay has elapsed. Any address may trigger execution; the
+    /// trustless guarantee comes from the approval + timelock checks, not from
+    /// who calls this function.
+    pub fn execute_action(env: Env, caller: Address, action_id: u64) -> Val {
+        caller.require_auth();
+
+        let mut action = storage::get_action(&env, action_id);
+        Self::require_pending(&env, &action);
+
+        let threshold = storage::get_threshold(&env);
+        if action.approvals.len() < threshold {
+            panic_with_error!(&env, AdapterError::ThresholdNotMet);
+        }
+
+        let timelock = storage::get_timelock(&env);
+        let executable_at = action.proposed_at.saturating_add(timelock);
+        if env.ledger().timestamp() < executable_at {
+            panic_with_error!(&env, AdapterError::TimelockNotElapsed);
+        }
+
+        action.executed = true;
+        storage::set_action(&env, &action);
+
+        let result: Val =
+            env.invoke_contract(&action.target, &action.function, action.args.clone());
+
+        events::emit_action_executed(&env, action_id, &action.target, &action.function);
+
+        result
+    }
+
+    /// Cancel a pending action. Requires authorization from the admin.
+    pub fn cancel_action(env: Env, admin: Address, action_id: u64) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+
+        let mut action = storage::get_action(&env, action_id);
+        if action.executed {
+            panic_with_error!(&env, AdapterError::ActionAlreadyExecuted);
+        }
+
+        action.canceled = true;
+        storage::set_action(&env, &action);
+
+        events::emit_action_canceled(&env, action_id);
+    }
+
+    /// Add an authorized signer. Requires authorization from the admin.
+    pub fn add_signer(env: Env, admin: Address, signer: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+
+        let mut signers = storage::get_signers(&env);
+        if signers.contains(&signer) {
+            panic_with_error!(&env, AdapterError::SignerAlreadyExists);
+        }
+
+        signers.push_back(signer.clone());
+        storage::set_signers(&env, &signers);
+
+        events::emit_signer_added(&env, &signer);
+    }
+
+    /// Remove an authorized signer. Requires authorization from the admin. Fails
+    /// if removing the signer would drop the signer count below the current
+    /// threshold.
+    pub fn remove_signer(env: Env, admin: Address, signer: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+
+        let mut signers = storage::get_signers(&env);
+        let index = match signers.iter().position(|s| s == signer) {
+            Some(index) => index,
+            None => panic_with_error!(&env, AdapterError::SignerNotFound),
+        };
+
+        let threshold = storage::get_threshold(&env);
+        if signers.len() - 1 < threshold {
+            panic_with_error!(&env, AdapterError::InvalidThreshold);
+        }
+
+        signers.remove(index as u32);
+        storage::set_signers(&env, &signers);
+
+        events::emit_signer_removed(&env, &signer);
+    }
+
+    /// Change the approval threshold. Requires authorization from the admin.
+    pub fn set_threshold(env: Env, admin: Address, threshold: u32) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+
+        let signers = storage::get_signers(&env);
+        if threshold == 0 || threshold > signers.len() {
+            panic_with_error!(&env, AdapterError::InvalidThreshold);
+        }
+
+        let old_threshold = storage::get_threshold(&env);
+        storage::set_threshold(&env, threshold);
+
+        events::emit_threshold_changed(&env, old_threshold, threshold);
+    }
+
+    /// Change the timelock delay (in seconds). Requires authorization from the admin.
+    pub fn set_timelock(env: Env, admin: Address, timelock_secs: u64) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+
+        let old_timelock = storage::get_timelock(&env);
+        storage::set_timelock(&env, timelock_secs);
+
+        events::emit_timelock_changed(&env, old_timelock, timelock_secs);
+    }
+
+    /// Set the admin address for this contract. Requires authorization from the
+    /// current admin.
+    pub fn set_admin(env: Env, admin: Address, new_admin: Address) {
+        admin.require_auth();
+        access::require_admin(&env, &admin);
+
+        storage::set_admin(&env, &new_admin);
+        events::emit_admin_changed(&env, &admin, &new_admin);
+    }
+
+    /// Get a proposed action by id.
+    pub fn get_action(env: Env, action_id: u64) -> Action {
+        storage::get_action(&env, action_id)
+    }
+
+    /// Whether an action has reached the required approval threshold.
+    pub fn is_approved(env: Env, action_id: u64) -> bool {
+        let action = storage::get_action(&env, action_id);
+        action.approvals.len() >= storage::get_threshold(&env)
+    }
+
+    /// Whether an action can be executed right now (approved, timelock elapsed,
+    /// not already executed or canceled).
+    pub fn is_executable(env: Env, action_id: u64) -> bool {
+        let action = storage::get_action(&env, action_id);
+        if action.executed || action.canceled {
+            return false;
+        }
+
+        let threshold = storage::get_threshold(&env);
+        let timelock = storage::get_timelock(&env);
+        let executable_at = action.proposed_at.saturating_add(timelock);
+
+        action.approvals.len() >= threshold && env.ledger().timestamp() >= executable_at
+    }
+
+    /// Get the current list of authorized signers.
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        storage::get_signers(&env)
+    }
+
+    /// Get the current approval threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        storage::get_threshold(&env)
+    }
+
+    /// Get the current timelock delay, in seconds.
+    pub fn get_timelock(env: Env) -> u64 {
+        storage::get_timelock(&env)
+    }
+
+    /// Get the current admin address.
+    pub fn get_admin(env: Env) -> Address {
+        storage::get_admin(&env)
+    }
+
+    fn require_pending(env: &Env, action: &Action) {
+        if action.executed {
+            panic_with_error!(env, AdapterError::ActionAlreadyExecuted);
+        }
+        if action.canceled {
+            panic_with_error!(env, AdapterError::ActionCanceled);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/contracts/adapter-trustless-contract/src/storage.rs
+++ b/contracts/adapter-trustless-contract/src/storage.rs
@@ -1,0 +1,101 @@
+use soroban_sdk::{panic_with_error, Address, Env, Vec};
+
+use crate::errors::AdapterError;
+use crate::types::{Action, DataKey};
+
+/// Persistent storage TTL for actions: ~30 days bump when accessed, extended if
+/// fewer than ~15 days remain.
+const ACTION_TTL_THRESHOLD: u32 = 259_200;
+const ACTION_TTL_EXTEND_TO: u32 = 518_400;
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic!("Admin not set"))
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_signers(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Signers)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_signers(env: &Env, signers: &Vec<Address>) {
+    env.storage().instance().set(&DataKey::Signers, signers);
+}
+
+pub fn is_signer(env: &Env, addr: &Address) -> bool {
+    get_signers(env).contains(addr)
+}
+
+pub fn get_threshold(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::Threshold)
+        .unwrap_or(0)
+}
+
+pub fn set_threshold(env: &Env, threshold: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Threshold, &threshold);
+}
+
+pub fn get_timelock(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TimelockSecs)
+        .unwrap_or(0)
+}
+
+pub fn set_timelock(env: &Env, timelock_secs: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::TimelockSecs, &timelock_secs);
+}
+
+/// Allocate and persist the next action id, starting from 1.
+pub fn next_action_id(env: &Env) -> u64 {
+    let next: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextActionId)
+        .unwrap_or(0)
+        + 1;
+
+    env.storage().instance().set(&DataKey::NextActionId, &next);
+    next
+}
+
+pub fn get_action(env: &Env, action_id: u64) -> Action {
+    let key = DataKey::Action(action_id);
+
+    let action: Action = match env.storage().persistent().get(&key) {
+        Some(action) => action,
+        None => panic_with_error!(env, AdapterError::ActionNotFound),
+    };
+
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, ACTION_TTL_THRESHOLD, ACTION_TTL_EXTEND_TO);
+
+    action
+}
+
+pub fn set_action(env: &Env, action: &Action) {
+    let key = DataKey::Action(action.id);
+    env.storage().persistent().set(&key, action);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, ACTION_TTL_THRESHOLD, ACTION_TTL_EXTEND_TO);
+}

--- a/contracts/adapter-trustless-contract/src/tests.rs
+++ b/contracts/adapter-trustless-contract/src/tests.rs
@@ -1,0 +1,507 @@
+use soroban_sdk::{
+    contract, contractimpl, symbol_short,
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, IntoVal, Symbol, Val, Vec,
+};
+
+use crate::AdapterTrustlessContract;
+use crate::AdapterTrustlessContractClient;
+
+// A minimal target contract used to exercise `execute_action`'s cross-contract
+// invocation. Mirrors the kind of admin-only setter the adapter is meant to guard.
+#[contract]
+pub struct MockTarget;
+
+#[contractimpl]
+impl MockTarget {
+    pub fn set_value(env: Env, value: u32) -> u32 {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("VALUE"), &value);
+        value
+    }
+
+    pub fn get_value(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("VALUE"))
+            .unwrap_or(0)
+    }
+}
+
+fn setup(env: &Env) -> (AdapterTrustlessContractClient<'_>, Vec<Address>, Address) {
+    let contract_id = env.register(AdapterTrustlessContract, ());
+    let client = AdapterTrustlessContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    (client, Vec::new(env), admin)
+}
+
+fn set_value_call(env: &Env, target: &Address, value: u32) -> (Address, Symbol, Vec<Val>) {
+    let mut args = Vec::new(env);
+    args.push_back(value.into_val(env));
+    (target.clone(), symbol_short!("set_value"), args)
+}
+
+/// Test: Initializes the adapter with signers, threshold and timelock
+#[test]
+fn it_initializes() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+
+    client.initialize(&admin, &signers, &2, &1000);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_signers(), signers);
+    assert_eq!(client.get_threshold(), 2);
+    assert_eq!(client.get_timelock(), 1000);
+}
+
+/// Test: Prevents double initialization
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn it_prevents_double_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer);
+
+    client.initialize(&admin, &signers, &1, &0);
+    client.initialize(&admin, &signers, &1, &0);
+}
+
+/// Test: Rejects an empty signer set
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn it_rejects_empty_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, signers, admin) = setup(&env);
+    client.initialize(&admin, &signers, &1, &0);
+}
+
+/// Test: Rejects a threshold greater than the number of signers
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn it_rejects_threshold_above_signer_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer);
+
+    client.initialize(&admin, &signers, &2, &0);
+}
+
+/// Test: A signer can propose an action, which auto-approves from the proposer
+#[test]
+fn it_proposes_action_with_proposer_auto_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer.clone());
+    client.initialize(&admin, &signers, &1, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+
+    let action_id = client.propose_action(&signer, &target, &function, &args);
+    assert_eq!(action_id, 1);
+
+    let action = client.get_action(&action_id);
+    assert_eq!(action.approvals.len(), 1);
+    assert_eq!(action.approvals.get(0).unwrap(), signer);
+    assert!(!action.executed);
+    assert!(!action.canceled);
+}
+
+/// Test: Only an authorized signer can propose an action
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn it_rejects_proposal_from_non_signer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer);
+    client.initialize(&admin, &signers, &1, &0);
+
+    let outsider = Address::generate(&env);
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 1);
+
+    client.propose_action(&outsider, &target, &function, &args);
+}
+
+/// Test: Executes an action once threshold and timelock are satisfied
+#[test]
+fn it_executes_action_after_threshold_and_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+
+    client.initialize(&admin, &signers, &2, &1000);
+
+    let target_id = env.register(MockTarget, ());
+    let target_client = MockTargetClient::new(&env, &target_id);
+    assert_eq!(target_client.get_value(), 0);
+
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer1, &target, &function, &args);
+
+    client.approve_action(&signer2, &action_id);
+
+    env.ledger().with_mut(|li| li.timestamp += 1000);
+
+    let caller = Address::generate(&env);
+    client.execute_action(&caller, &action_id);
+
+    assert_eq!(target_client.get_value(), 42);
+
+    let action = client.get_action(&action_id);
+    assert!(action.executed);
+}
+
+/// Test: Cannot execute before the approval threshold is met
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn it_prevents_execution_below_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+
+    client.initialize(&admin, &signers, &2, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer1, &target, &function, &args);
+
+    let caller = Address::generate(&env);
+    client.execute_action(&caller, &action_id);
+}
+
+/// Test: Cannot execute before the timelock has elapsed
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn it_prevents_execution_before_timelock_elapses() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer.clone());
+    client.initialize(&admin, &signers, &1, &1000);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer, &target, &function, &args);
+
+    let caller = Address::generate(&env);
+    client.execute_action(&caller, &action_id);
+}
+
+/// Test: Cannot execute the same action twice
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn it_prevents_double_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer.clone());
+    client.initialize(&admin, &signers, &1, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer, &target, &function, &args);
+
+    let caller = Address::generate(&env);
+    client.execute_action(&caller, &action_id);
+    client.execute_action(&caller, &action_id);
+}
+
+/// Test: A signer cannot approve the same action twice
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn it_prevents_double_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+    client.initialize(&admin, &signers, &2, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer1, &target, &function, &args);
+
+    client.approve_action(&signer1, &action_id);
+}
+
+/// Test: A signer can revoke their approval before execution
+#[test]
+fn it_revokes_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+    client.initialize(&admin, &signers, &2, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer1, &target, &function, &args);
+
+    client.approve_action(&signer2, &action_id);
+    assert!(client.is_approved(&action_id));
+
+    client.revoke_approval(&signer2, &action_id);
+    assert!(!client.is_approved(&action_id));
+
+    let action = client.get_action(&action_id);
+    assert_eq!(action.approvals.len(), 1);
+}
+
+/// Test: Admin can cancel a pending action, blocking execution
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn it_cancels_action() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer.clone());
+    client.initialize(&admin, &signers, &1, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer, &target, &function, &args);
+
+    client.cancel_action(&admin, &action_id);
+
+    let caller = Address::generate(&env);
+    client.execute_action(&caller, &action_id);
+}
+
+/// Test: Only the admin can cancel an action
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn it_rejects_cancel_from_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer.clone());
+    client.initialize(&admin, &signers, &1, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 42);
+    let action_id = client.propose_action(&signer, &target, &function, &args);
+
+    let outsider = Address::generate(&env);
+    client.cancel_action(&outsider, &action_id);
+}
+
+/// Test: Admin can add and remove signers
+#[test]
+fn it_adds_and_removes_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    client.initialize(&admin, &signers, &1, &0);
+
+    let signer2 = Address::generate(&env);
+    client.add_signer(&admin, &signer2);
+    assert_eq!(client.get_signers().len(), 2);
+
+    client.remove_signer(&admin, &signer1);
+    assert_eq!(client.get_signers().len(), 1);
+    assert!(!client.get_signers().contains(&signer1));
+}
+
+/// Test: Cannot remove a signer if it would drop below the current threshold
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn it_prevents_removing_signer_below_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+    client.initialize(&admin, &signers, &2, &0);
+
+    client.remove_signer(&admin, &signer1);
+}
+
+/// Test: Admin can raise or lower the threshold within signer bounds
+#[test]
+fn it_changes_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1);
+    signers.push_back(signer2);
+    client.initialize(&admin, &signers, &1, &0);
+
+    client.set_threshold(&admin, &2);
+    assert_eq!(client.get_threshold(), 2);
+}
+
+/// Test: Admin can change the timelock delay
+#[test]
+fn it_changes_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer);
+    client.initialize(&admin, &signers, &1, &0);
+
+    client.set_timelock(&admin, &500);
+    assert_eq!(client.get_timelock(), 500);
+}
+
+/// Test: Admin can transfer admin rights
+#[test]
+fn it_transfers_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer);
+    client.initialize(&admin, &signers, &1, &0);
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+/// Test: Fetching an unknown action id panics with ActionNotFound
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn it_fails_on_unknown_action() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer);
+    client.initialize(&admin, &signers, &1, &0);
+
+    client.get_action(&99);
+}
+
+/// Test: Emits ACTNEXEC event on execution
+#[test]
+fn it_emits_action_executed_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _unused, admin) = setup(&env);
+
+    let signer = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer.clone());
+    client.initialize(&admin, &signers, &1, &0);
+
+    let target_id = env.register(MockTarget, ());
+    let (target, function, args) = set_value_call(&env, &target_id, 7);
+    let action_id = client.propose_action(&signer, &target, &function, &args);
+
+    let caller = Address::generate(&env);
+    client.execute_action(&caller, &action_id);
+
+    let events: Vec<(Address, Vec<Val>, Val)> = env.events().all();
+
+    let mut found = false;
+    for event in events.iter() {
+        let topics = event.1.clone();
+        let event_type: Symbol = topics.get(0).unwrap().into_val(&env);
+
+        if event_type == symbol_short!("ACTNEXEC") {
+            found = true;
+            break;
+        }
+    }
+
+    assert!(found, "ACTNEXEC event not found");
+}

--- a/contracts/adapter-trustless-contract/src/types.rs
+++ b/contracts/adapter-trustless-contract/src/types.rs
@@ -1,0 +1,33 @@
+use soroban_sdk::{contracttype, Address, Symbol, Val, Vec};
+
+/// A proposed cross-contract call, gated by multi-sig approval and a timelock.
+#[contracttype]
+#[derive(Clone)]
+pub struct Action {
+    pub id: u64,
+    pub target: Address,
+    pub function: Symbol,
+    pub args: Vec<Val>,
+    pub proposer: Address,
+    pub proposed_at: u64,
+    pub approvals: Vec<Address>,
+    pub executed: bool,
+    pub canceled: bool,
+}
+
+/// Storage keys for the adapter-trustless-contract
+#[contracttype]
+pub enum DataKey {
+    /// Admin address (instance storage)
+    Admin,
+    /// Authorized signers (instance storage)
+    Signers,
+    /// Number of approvals required to execute an action (instance storage)
+    Threshold,
+    /// Minimum delay, in seconds, between proposal and execution (instance storage)
+    TimelockSecs,
+    /// Next action id to assign (instance storage)
+    NextActionId,
+    /// Proposed action (persistent storage), keyed by action id
+    Action(u64),
+}

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -345,6 +345,112 @@ after 1 year (8% APY): 1 share = $1.08
 
 ---
 
+## Adapter Trustless Contract ✅
+
+**Status**: Implemented and tested
+
+**Purpose**: Remove the single-admin trust assumption from privileged, cross-contract
+operations. Each TrustUp contract gates sensitive operations (changing an admin,
+updating a cross-contract address, tuning risk parameters) behind a single `admin`
+address — a single point of failure and of trust. The adapter is a generic **M-of-N
+multi-sig + timelock gateway**: instead of an admin calling a privileged function
+directly, a signer proposes the call, a threshold of signers approve it, and only
+after a configured timelock delay can anyone trigger its execution. No single
+signer, including the adapter's own admin, can execute a privileged call alone.
+
+### Architecture
+
+**State**:
+```rust
+pub enum DataKey {
+    Admin,              // Instance: Admin address
+    Signers,            // Instance: Vec<Address> of authorized signers
+    Threshold,          // Instance: u32 approvals required to execute
+    TimelockSecs,       // Instance: u64 delay (seconds) between proposal and execution
+    NextActionId,       // Instance: u64 counter
+    Action(u64),        // Persistent: ActionId → Action
+}
+
+pub struct Action {
+    pub id: u64,
+    pub target: Address,        // Contract to call
+    pub function: Symbol,       // Function to invoke
+    pub args: Vec<Val>,         // Call arguments
+    pub proposer: Address,
+    pub proposed_at: u64,       // Ledger timestamp of proposal
+    pub approvals: Vec<Address>,
+    pub executed: bool,
+    pub canceled: bool,
+}
+```
+
+**Public API**:
+```rust
+// Setup
+pub fn initialize(env: Env, admin: Address, signers: Vec<Address>, threshold: u32, timelock_secs: u64)
+
+// Proposal lifecycle
+pub fn propose_action(env: Env, proposer: Address, target: Address, function: Symbol, args: Vec<Val>) -> u64
+pub fn approve_action(env: Env, signer: Address, action_id: u64)
+pub fn revoke_approval(env: Env, signer: Address, action_id: u64)
+pub fn execute_action(env: Env, caller: Address, action_id: u64) -> Val
+pub fn cancel_action(env: Env, admin: Address, action_id: u64)
+
+// Signer / config management (admin only)
+pub fn add_signer(env: Env, admin: Address, signer: Address)
+pub fn remove_signer(env: Env, admin: Address, signer: Address)
+pub fn set_threshold(env: Env, admin: Address, threshold: u32)
+pub fn set_timelock(env: Env, admin: Address, timelock_secs: u64)
+
+// Queries
+pub fn get_action(env: Env, action_id: u64) -> Action
+pub fn is_approved(env: Env, action_id: u64) -> bool
+pub fn is_executable(env: Env, action_id: u64) -> bool
+pub fn get_signers(env: Env) -> Vec<Address>
+pub fn get_threshold(env: Env) -> u32
+pub fn get_timelock(env: Env) -> u64
+pub fn get_admin(env: Env) -> Address
+```
+
+**Business Logic**:
+
+1. **Proposal**: Any authorized signer proposes a target contract, function, and
+   argument list. The proposer's approval is recorded immediately.
+2. **Approval**: Other signers approve; each signer may approve once and may revoke
+   their approval any time before execution.
+3. **Execution**: Once approvals reach `threshold` **and** `proposed_at + timelock`
+   has elapsed, any address can call `execute_action`, which invokes the target
+   contract via `Env::invoke_contract` and marks the action executed.
+4. **Cancellation**: The admin can cancel a pending action, which blocks execution
+   permanently — used to reject inappropriate proposals without disabling the
+   whole adapter.
+
+**Events**:
+- `ACTNPROP` / `ACTNAPPRV` / `ACTNREVK` / `ACTNEXEC` / `ACTNCANC`: Action lifecycle
+- `SIGNERADD` / `SIGNERRM`: Signer set changes
+- `THRESHCHG` / `TMLOCKCHG`: Config changes
+- `ADMINCHGD`: Admin changed
+
+**Access Control**:
+- Signers: Can propose, approve, and revoke their own approval
+- Admin: Can cancel actions and manage signers/threshold/timelock
+- Public: Can execute any action that has met threshold + timelock, and can read
+  any action
+
+**Security Features**:
+- Threshold enforced against the current signer count on every config change
+  (`remove_signer` and `set_threshold` both re-validate the invariant)
+- Timelock computed with `saturating_add` to avoid overflow
+- Execution and cancellation are idempotent-safe (`executed`/`canceled` flags)
+- Event emission for every state change, for off-chain auditability
+
+**What it does *not* do**: it does not replace each contract's own `admin` field —
+contracts must be reconfigured to name the adapter (or an address it controls) as
+their admin/updater to have its guarantees enforced. It is also a generic relay: it
+does not interpret or validate the semantics of the calls it forwards.
+
+---
+
 ## Contract Interactions
 
 ### Create Loan Flow
@@ -413,5 +519,6 @@ All contracts follow upgrade pattern:
 ## Resources
 
 - [Reputation Contract Source](../../contracts/reputation-contract/src/lib.rs)
+- [Adapter Trustless Contract Source](../../contracts/adapter-trustless-contract/src/lib.rs)
 - [Roadmap](../ROADMAP.md) - Implementation timeline
 - [Storage Patterns](storage-patterns.md) - Storage best practices


### PR DESCRIPTION
# Pull Request

## Description
The `contracts/adapter-trustless-contract/` directory only had a `.gitkeep` file and no defined purpose (#84). Every other TrustUp contract gates privileged operations (changing an admin, updating a cross-contract address, tuning risk parameters) behind a single `admin` address, which is a single point of trust and failure. This PR defines and implements the adapter as a generic **M-of-N multi-sig + timelock gateway**: a signer proposes a cross-contract call, a threshold of signers must approve it, and execution is only possible once a configured timelock delay has elapsed — so no single signer, including the adapter's own admin, can act unilaterally.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made
- Added `contracts/adapter-trustless-contract` as a new workspace member, following the standard 7-module layout (`lib.rs`, `types.rs`, `errors.rs`, `storage.rs`, `access.rs`, `events.rs`, `tests.rs`) used by `reputation-contract`
- Implemented the proposal lifecycle: `propose_action`, `approve_action`, `revoke_approval`, `execute_action`, `cancel_action`
- Implemented signer/config management: `add_signer`, `remove_signer`, `set_threshold`, `set_timelock`, `set_admin`
- `execute_action` performs the actual cross-contract call via `Env::invoke_contract`, gated on approval threshold + timelock
- Added query functions: `get_action`, `is_approved`, `is_executable`, `get_signers`, `get_threshold`, `get_timelock`, `get_admin`
- Added a `contracts-ci.yml` step to build the new contract's WASM target (the existing `cargo test`/`cargo build` steps already cover it as a workspace member)
- Documented the contract's purpose and architecture in `docs/architecture/contracts.md` and in the contract's own `README.md`

## Testing
- [x] Tests pass locally
- [x] New tests added (if applicable)

21 unit tests covering: initialization and its invariants, proposal + auto-approval, threshold enforcement, timelock enforcement, double-approval/double-execution guards, revocation, cancellation, signer/threshold/timelock/admin management, and actual cross-contract execution against a mock target contract (`env.invoke_contract`). Also verified `cargo fmt -- --check`, `cargo clippy -p adapter-trustless-contract --all-targets -- -D warnings`, and the WASM release build all pass, plus the full workspace test suite (`cargo test --workspace`).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated

## Closes
Closes #84

## Notes
This issue's description offered several "likely candidate" purposes for the adapter (escrow, external DeFi liquidity adapter, or multi-sig/timelock admin guard) without settling on one, since the contract had no prior design doc. I went with the multi-sig/timelock admin guard: it best matches the literal meaning of "trustless adapter" (removing trust from a single admin key), it's self-contained with no dependency on an unimplemented external protocol integration, and it doesn't overlap with the escrow logic already implemented in `creditline-contract`. Happy to adjust the design if maintainers prefer a different direction.

Wiring existing contracts' `admin` fields to route through this adapter is left as a follow-up, since that's a migration decision for each contract's maintainers rather than something this issue asked for.